### PR TITLE
chore: leverage useIsMounted hook

### DIFF
--- a/src/components/Utils/ClientOnly.tsx
+++ b/src/components/Utils/ClientOnly.tsx
@@ -1,13 +1,10 @@
 import { PropsWithChildren, useEffect, useState } from "react"
+import { useIsMounted } from "../../utils/hookts"
 
 export default function ClientOnly({ children, ...delegated }: PropsWithChildren<{}>) {
-  const [hasMounted, setHasMounted] = useState(false);
+  const isMounted = useIsMounted();
 
-  useEffect(() => {
-    setHasMounted(true);
-  }, [])
-
-  if (!hasMounted) {
+  if (!isMounted()) {
     return null
   }
 
@@ -15,15 +12,5 @@ export default function ClientOnly({ children, ...delegated }: PropsWithChildren
 }
 
 export function ClientOnlyEmpty({ children }: PropsWithChildren<{}>) {
-  const [hasMounted, setHasMounted] = useState(false);
-
-  useEffect(() => {
-    setHasMounted(true);
-  }, [])
-
-  if (!hasMounted) {
-    return null
-  }
-
-  return <>{children}</>
+  return <ClientOnly>{children}</ClientOnly>
 }


### PR DESCRIPTION
Objective:
drop `ClientOnly` / `ClientOnlyEmpty`'s own implementation of isMounted check in favor of `useIsMounted` hook

Thanks for the clean and very readable code base and I do learn from it a lot :) 

Notes:
* I don't seem to find any tests being setup so it's probably too early to do this, please let me know if adding few tests would be appropriate atm
* It's uncertain to me if `hookts` is named this way intentionally so I just keep it