### PR TITLE
✨ optimize community reports page

### DIFF
--- a/src/pages/community/reports.tsx
+++ b/src/pages/community/reports.tsx
@@ -142,7 +142,7 @@ const ReportsPage: NextPage<Props> = ({
   )
 }
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   const { data } = await client.query({
     query: Qu_reportedGenTokens,
     fetchPolicy: "no-cache",
@@ -156,6 +156,7 @@ export async function getServerSideProps() {
     props: {
       tokens: data.reportedGenerativeTokens,
     },
+    revalidate: 60
   }
 }
 


### PR DESCRIPTION
community reports page always hit the backend to retrieve content. Currently it's a public page and all members / visotrs might see the same content regardless. We can build the page and always serve the cache when appropriate and rebuild page periodically.