### PR TITLE
🐛 don't show calculated open/close time if the contract has been manually paused

### DIFF
--- a/src/components/Utils/ContractsOpened.tsx
+++ b/src/components/Utils/ContractsOpened.tsx
@@ -9,31 +9,36 @@ export function ContractsOpened() {
   const { data: issuerStorage } = useContractStorage(process.env.NEXT_PUBLIC_TZ_CT_ADDRESS_ISSUER!)
   const [timeUntilClose, setTimeUntilClose] = useState<number>(0)
   const [nextCycleStart, setNextCycleStart] = useState<number>(0)
+  const [cyclePaused, setCyclePaused] = useState<Boolean>(false);
   const [mintTimeStatus, setMintTimeStatus] = useState<string>()
-  
+
   useEffect(() => {
     setTimeUntilClose(getMsUntilClose())
     setNextCycleStart(getNextCycleStartTime())
     if (timeUntilClose < 0) {
       // we are closed
+      setCyclePaused(true);
       const nextOpen = new Date(nextCycleStart)
-      const nextOpenString = nextOpen.toLocaleTimeString("en-US", {hour:'numeric'})
+      const nextOpenString = nextOpen.toLocaleTimeString("en-US", { hour: 'numeric' })
       setMintTimeStatus(`(opens at ${nextOpenString})`)
     }
     else {
       // we are open
+      setCyclePaused(false);
       const nextClose = new Date(Date.now() + timeUntilClose)
-      const nextCloseString = nextClose.toLocaleTimeString("en-US", {hour:'numeric'})
+      const nextCloseString = nextClose.toLocaleTimeString("en-US", { hour: 'numeric' })
       setMintTimeStatus(`(closes at ${nextCloseString})`)
     }
   })
-  
+
   return issuerStorage ? (
     <div className={cs(style.state, { [style.state_closed]: issuerStorage.paused })}>
       <span>
-        MINT {issuerStorage.paused ? "CLOSED" : "OPENED"} {mintTimeStatus}
+        {/* occasionally we override the open/close schedule, so only show
+        the estimated opening time if the cycle's pause matches the contract's */}
+        MINT {issuerStorage.paused ? "CLOSED" : "OPENED"} {(issuerStorage.paused === cyclePaused) && mintTimeStatus}
       </span>
-      <div/>
+      <div />
     </div>
-  ):null
+  ) : null
 }


### PR DESCRIPTION
This omits printing the open/close time string if the contract's `paused` field doesn't match the calculated value. Avoids confusing situations like this one:
![image](https://user-images.githubusercontent.com/1361935/146451948-58333f7d-4760-4d9e-9cbd-4f346fc30062.png)

instead just going back to the old style:
![image](https://user-images.githubusercontent.com/1361935/146451856-4b9b3e7b-c1bd-4723-8caa-6cd4b78ab7a6.png)
