### PR TITLE
Added price to generative card so it displays on Explore Page.

### DIFF
--- a/src/components/Card/GenerativeTokenCard.tsx
+++ b/src/components/Card/GenerativeTokenCard.tsx
@@ -8,6 +8,8 @@ import { UserBadge } from "../User/UserBadge"
 import { MintProgress } from "../Artwork/MintProgress"
 import { Spacing } from "../Layout/Spacing"
 import { getGenerativeTokenUrl } from "../../utils/generative-token"
+import { displayMutez } from "../../utils/units"
+
 
 interface Props {
   token: GenerativeToken
@@ -32,6 +34,7 @@ export function GenerativeTokenCard({
           <div>
             <Spacing size="small" />
             <MintProgress balance={token.balance} supply={token.supply} />
+            {displayMutez(token.price)} tez
           </div>
         </Card>
       </AnchorForward>


### PR DESCRIPTION
Adding price to explore page, so that users can easilly decide which pieces stand out based on interest and price. Without having to open every piece to find out the price.