### PR TITLE
Show floor price of each collection on User Collection page

### DIFF
--- a/src/components/Card/ObjktCard.tsx
+++ b/src/components/Card/ObjktCard.tsx
@@ -40,13 +40,13 @@ export function ObjktCard({
 
           <div className={cs(style.bottom)}>
             <div className={cs(style.price)}>
-              {(objkt.offer && objkt.issuer.marketStats && settings.displayFloorPriceCard) ? (
+              {(objkt.offer && settings.displayFloorPriceCard && objkt.issuer.marketStats && objkt.issuer.marketStats.secVolumeNb ) ? (
                 <>{displayMutez(objkt.offer.price)} tez (floor {displayMutez(objkt.issuer.marketStats.floor)} tez)</>
+              ) : (objkt.issuer.marketStats && settings.displayFloorPriceCard && objkt.issuer.marketStats.secVolumeNb) ? (
+                <>Floor {displayMutez(objkt.issuer.marketStats.floor)} tez</>
               ) : (objkt.offer) ? (
                 <>{displayMutez(objkt.offer.price)} tez</>
-              ) : (objkt.issuer.marketStats && settings.displayFloorPriceCard && (
-                <>Floor {displayMutez(objkt.issuer.marketStats.floor)} tez</>
-              ))}
+              ) : (<></>)}
             </div>
             <div className={cs(style.badge)}>
               created by 

--- a/src/components/Card/ObjktCard.tsx
+++ b/src/components/Card/ObjktCard.tsx
@@ -1,6 +1,7 @@
 // import style from "./GenerativeTokenCard.module.scss"
 import Link from "next/link"
 import cs from "classnames"
+import { useContext } from "react";
 import { AnchorForward } from "../Utils/AnchorForward"
 import { Card } from "./Card"
 import { UserBadge } from "../User/UserBadge"
@@ -11,6 +12,7 @@ import { Objkt } from "../../types/entities/Objkt"
 import { displayMutez } from "../../utils/units"
 import { getObjktUrl } from "../../utils/objkt"
 import { GenTokFlag } from "../../types/entities/GenerativeToken"
+import { SettingsContext } from "../../context/Theme";
 
 interface Props {
   objkt: Objkt
@@ -21,6 +23,7 @@ export function ObjktCard({
 }: Props) {
   const owner = objkt.offer ? objkt.offer.issuer : objkt.owner!
   const url = getObjktUrl(objkt)
+  const settings = useContext(SettingsContext)
 
   return (
     <Link href={url} passHref>
@@ -37,9 +40,13 @@ export function ObjktCard({
 
           <div className={cs(style.bottom)}>
             <div className={cs(style.price)}>
-              {objkt.offer && (
+              {(objkt.offer && objkt.issuer.marketStats && settings.displayFloorPriceCard) ? (
+                <>{displayMutez(objkt.offer.price)} tez (floor {displayMutez(objkt.issuer.marketStats.floor)} tez)</>
+              ) : (objkt.offer) ? (
                 <>{displayMutez(objkt.offer.price)} tez</>
-              )}
+              ) : (objkt.issuer.marketStats && settings.displayFloorPriceCard && (
+                <>Floor {displayMutez(objkt.issuer.marketStats.floor)} tez</>
+              ))}
             </div>
             <div className={cs(style.badge)}>
               created by 

--- a/src/containers/Settings/Settings.tsx
+++ b/src/containers/Settings/Settings.tsx
@@ -25,6 +25,13 @@ export function Settings({
         onChange={(value) => settings.update("displayPricesCard", value)} 
         value={settings.displayPricesCard}
       />
+
+      <strong>Display floor price</strong>
+      <Switch 
+        onChange={(value) => settings.update("displayFloorPriceCard", value)} 
+        value={settings.displayFloorPriceCard}
+      />
+
     </div>
   )  
 }

--- a/src/context/Theme.tsx
+++ b/src/context/Theme.tsx
@@ -7,6 +7,7 @@ import cs from "classnames"
 interface ISettingsProperties {
   darkTheme: boolean
   displayPricesCard: boolean
+  displayFloorPriceCard: boolean
 }
 
 interface ISettingsContext extends ISettingsProperties {
@@ -15,7 +16,8 @@ interface ISettingsContext extends ISettingsProperties {
 
 const defaultProperties: ISettingsProperties = {
   darkTheme: false,
-  displayPricesCard: false
+  displayPricesCard: false,
+  displayFloorPriceCard: false
 }
 
 const defaultCtx: ISettingsContext = {

--- a/src/queries/user.ts
+++ b/src/queries/user.ts
@@ -60,6 +60,7 @@ export const Qu_userObjkts = gql`
           },
           marketStats {
             floor
+            secVolumeNb
           }
         }
         name

--- a/src/queries/user.ts
+++ b/src/queries/user.ts
@@ -57,6 +57,9 @@ export const Qu_userObjkts = gql`
             id
             name
             avatarUri
+          },
+          marketStats {
+            floor
           }
         }
         name


### PR DESCRIPTION
As a collector it is great to be able to mint a lot of art, but from time to time you need to sell some excess mints to fund additional minting. This PR intends to make it easier to identify which tokens can likely be sold at what price (the floor price).

The PR only modifies the User Collection page. The functionality is gated behind a new optional setting named "Display floor price". When enabled, the floor price of a collection is shown on the token card, either alone or together with the current offer price.

The floor price is only shown if there has been at least one secondary sale for the collection already. The rationale behind this choice is that a collection that has not seen any sales yet will have highly unreliable floor prices. Once the sales start to happen,  the price discovery is in effect and the buyers determine how much they value pieces from the collection.