### PR TITLE
Bugfix for error while scrolling a token's activity list

### DIFF
--- a/src/components/User/UserBadge.tsx
+++ b/src/components/User/UserBadge.tsx
@@ -18,8 +18,8 @@ interface WrapperProps {
   children: ReactNode
 }
 
-const WrapperLink = ({ 
-  className, 
+const WrapperLink = ({
+  className,
   user,
   children,
 }: WrapperProps) => (
@@ -30,8 +30,8 @@ const WrapperLink = ({
   </Link>
 )
 
-const WrapperDiv = ({ 
-  className, 
+const WrapperDiv = ({
+  className,
   user,
   children,
 }: WrapperProps) => (
@@ -51,20 +51,20 @@ export function UserBadge({
   className
 }: Props) {
   // the user goes through an aliases check
-  const userAlias = useMemo(() => userAliases(user), [user])
-  const verified = isUserVerified(user)
+  const userAlias = useMemo(() => user && userAliases(user), [user])
+  const verified = user && isUserVerified(user)
   // alias can force no link
-  hasLink = hasLink && !userAlias.preventLink
+  hasLink = user && hasLink && !userAlias.preventLink
   // the wrapper component, either a link or a div
   const Wrapper = hasLink ? WrapperLink : WrapperDiv
 
-  return (
-    <Wrapper 
+  return user ? (
+    <Wrapper
       className={cs(style.container, style[`side-${avatarSide}`], className)}
       user={userAlias}
     >
       {displayAvatar && (
-        <Avatar 
+        <Avatar
           uri={userAlias.avatarUri}
           className={cs(
             style.avatar,
@@ -73,7 +73,7 @@ export function UserBadge({
           )}
         />
       )}
-  
+
       <div className={cs(style.user_infos)}>
         <span className={cs(style.user_name)}>
           {prependText && (
@@ -83,8 +83,8 @@ export function UserBadge({
             {getUserName(userAlias, 15)}
           </span>
           {verified && (
-            <i 
-              aria-hidden 
+            <i
+              aria-hidden
               className={cs("fas", "fa-badge-check", style.verified)}
             />
           )}
@@ -97,5 +97,5 @@ export function UserBadge({
         )}
       </div>
     </Wrapper>
-  )
+  ) : <></>
 }


### PR DESCRIPTION
I'm referring to this error:

https://user-images.githubusercontent.com/3226096/164323669-1ece5d0f-a403-460a-9e5c-75769920d834.mp4

steps to reproduce:
 - open project page
 - click on the "activity" tab
 - scroll until error

it happens because actions of type `UPDATE_PRICING` and `UPDATE_STATE` have a `null` issuer, and the component `UserBadge` doesn't check if the user is `null`

(it happens only if in the fetched actions there are some of type `UPDATE_PRICING` and `UPDATE_STATE`, that's why on some pages it doesn't happen or it crashes only after older data is fetched while scrolling)

My solution: don't show UserBadge if user is undefined

I know it is not really a front-end issue because the issuer should (probably) always be returned, but this way it can't crash if it doesn't (like it does now)

here is how it looks "fixed":

![20220420_160208_chrome_vtR0unG4Ol](https://user-images.githubusercontent.com/3226096/164323742-e5f4a040-781b-4f9f-bb0b-c9472c23e92f.png)

_notice how "updated state" and "updated price" actions don't have a UserBadge on the left_