### PR TITLE
Appends marketplace search filters to URL. Closes #30

### DIFF
--- a/src/components/Input/SearchInputControlled.tsx
+++ b/src/components/Input/SearchInputControlled.tsx
@@ -1,10 +1,12 @@
 import cs from "classnames"
-import { useState } from "react"
+import { useRouter } from "next/router"
+import { useEffect, useState } from "react"
 import { SearchInput } from "./SearchInput"
 
 interface Props {
   onSearch: (query: string) => void
   placeholder?: string
+  initialValue?: string
   className?: string
 }
 
@@ -16,9 +18,10 @@ interface Props {
 export function SearchInputControlled({
   placeholder = "search by artist name, tags, title...",
   onSearch,
+  initialValue = "",
   className,
 }: Props) {
-  const [value, setValue] = useState<string>("")
+  const [value, setValue] = useState<string>(initialValue)
 
   return (
     <SearchInput

--- a/src/containers/Marketplace.tsx
+++ b/src/containers/Marketplace.tsx
@@ -18,6 +18,7 @@ import { ExploreTagDef, ExploreTags } from "../components/Exploration/ExploreTag
 import { displayMutez } from "../utils/units"
 import { SearchInputControlled } from "../components/Input/SearchInputControlled"
 import { Qu_listings } from "../queries/listing"
+import { useRouter } from "next/router"
 
 
 const ITEMS_PER_PAGE = 40
@@ -58,17 +59,66 @@ function sortValueToSortVariable(val: string) {
 }
 
 interface Props {
+  urlQuery: Record<string, string>
 }
 
-export const Marketplace = ({}: Props) => {
+const getFiltersFromUrlQuery = (urlQuery: Record<string, string>) => {
+  const {
+    search,
+    price_gte,
+    price_lte,
+    fullMint,
+    verified,
+    supply_lte,
+    supply_gte
+  } = urlQuery
+
+  // check all filters except for the search parameter
+  let p_lte = price_lte ? parseFloat(price_lte) : undefined
+  let p_gte = price_gte ? parseFloat(price_gte) : undefined
+  let ts_lte = supply_lte ? parseInt(supply_lte) : undefined
+  let ts_gte = supply_gte ? parseInt(supply_gte) : undefined
+  let loadedFilters: ListingFilters = {}
+  if (p_lte && p_lte !== NaN) loadedFilters.price_lte = p_lte.toString()
+  if (p_gte && p_gte !== NaN) loadedFilters.price_gte = p_gte.toString()
+  if (fullMint) loadedFilters.fullyMinted_eq = fullMint === "1"
+  if (verified) loadedFilters.authorVerified_eq = verified === "1"
+  if (ts_lte && ts_lte !== NaN) loadedFilters.tokenSupply_lte = ts_lte
+  if (ts_gte && ts_gte !== NaN) loadedFilters.tokenSupply_gte = ts_gte
+
+  // if there is a search query, add the searchQuery_eq filter and load the correct sort options
+  if (search) loadedFilters.searchQuery_eq = search
+
+  // set all loaded filters
+  return loadedFilters
+}
+
+const getSortFromUrlQuery = (urlQuery: Record<string, string>) => {
+  const { search, sort } = urlQuery
+
+  // if there is a sort value in the url, pre-select it in the sort input
+  // else, select the default value
+  let defaultSortValue = search ? 'relevance-desc' : 'createdAt-desc'
+  if (sort) {
+    let sortValues = search ? searchSortOptions : generalSortOptions
+    return sortValues.map(({ value }) => value).includes(sort)
+      ? sort
+      : defaultSortValue
+  }
+
+  return defaultSortValue
+}
+
+export const Marketplace = ({ urlQuery }: Props) => {
+
   // sort variables
-  const [sortValue, setSortValue] = useState<string>("createdAt-desc")
+  const [sortValue, setSortValue] = useState<string>(getSortFromUrlQuery(urlQuery))
   const sort = useMemo<Record<string, any>>(
-    () => sortValueToSortVariable(sortValue), 
+    () => sortValueToSortVariable(sortValue),
     [sortValue]
   )
   // sort options - when the search is triggered, options are updated to include relevance
-  const [sortOptions, setSortOptions] = useState<IOptions[]>(generalSortOptions)
+  const [sortOptions, setSortOptions] = useState<IOptions[]>(urlQuery.search ? searchSortOptions : generalSortOptions)
   // keeps track of the search option used before the search was triggered
   const sortBeforeSearch = useRef<string>(sortValue)
 
@@ -80,7 +130,7 @@ export const Marketplace = ({}: Props) => {
   }, [sortValue])
 
   // filters
-  const [filters, setFilters] = useState<ListingFilters>({})
+  const [filters, setFilters] = useState<ListingFilters>(getFiltersFromUrlQuery(urlQuery))
 
   // reference to an element at the top to scroll back
   const topMarkerRef = useRef<HTMLDivElement>(null)
@@ -99,8 +149,42 @@ export const Marketplace = ({}: Props) => {
     }
   })
 
+  const router = useRouter()
+  // update url parameters on filters changes
   useEffect(() => {
-    if (!loading) {
+
+    const {
+      price_gte,
+      price_lte,
+      fullyMinted_eq,
+      authorVerified_eq,
+      searchQuery_eq,
+      tokenSupply_lte,
+      tokenSupply_gte
+    } = filters
+
+    let query: any = {}
+
+    if (price_gte && price_gte !== 'NaN') query.price_gte = encodeURIComponent(price_gte)
+    if (price_lte && price_lte !== 'NaN') query.price_lte = encodeURIComponent(price_lte)
+    if (fullyMinted_eq !== undefined) query.fullMint = encodeURIComponent(fullyMinted_eq ? '1' : '0')
+    if (authorVerified_eq !== undefined) query.verified = encodeURIComponent(authorVerified_eq ? '1' : '0')
+    if (searchQuery_eq) query.search = encodeURIComponent(searchQuery_eq)
+    if (tokenSupply_lte && tokenSupply_lte !== NaN) query.supply_lte = encodeURIComponent(tokenSupply_lte)
+    if (tokenSupply_gte && tokenSupply_gte !== NaN) query.supply_gte = encodeURIComponent(tokenSupply_gte)
+
+    query.sort = encodeURIComponent(sortValue)
+
+    router.push(
+      { pathname: router.pathname, query },
+      `${router.pathname}?${Object.keys(query).map(key => `${key}=${query[key]}`).join('&')}`,
+      { shallow: true }
+    )
+
+  }, [filters, sortValue])
+
+  useEffect(() => {
+    if (!loading && data) {
       if (currentLength.current === data.listings?.length) {
         console.log("end current")
         ended.current = true
@@ -109,7 +193,7 @@ export const Marketplace = ({}: Props) => {
         currentLength.current = data.listings?.length
       }
     }
-  }, [loading])
+  }, [loading, data])
 
   const infiniteScrollFetch = () => {
     !ended.current && fetchMore?.({
@@ -143,11 +227,13 @@ export const Marketplace = ({}: Props) => {
     setFilters({
       ...filters,
       [filter]: value
-    })  
+    })
   }
 
   const removeFilter = (filter: string) => {
-    addFilter(filter, undefined)
+    let updatedFilters = { ...filters }
+    delete updatedFilters[filter as keyof ListingFilters]
+    setFilters(updatedFilters)
     // if the filter is search string, we reset the sort to what ti was
     if (filter === "searchQuery_eq" && sortValue === "relevance-desc") {
       setSortValue(sortBeforeSearch.current)
@@ -157,9 +243,10 @@ export const Marketplace = ({}: Props) => {
 
   // build the list of filters
   const filterTags = useMemo<ExploreTagDef[]>(() => {
+
     const tags: ExploreTagDef[] = []
     for (const key in filters) {
-      let value: string|null = null
+      let value: string | null = null
       // @ts-ignore
       if (filters[key] !== undefined) {
         switch (key) {
@@ -205,12 +292,12 @@ export const Marketplace = ({}: Props) => {
 
   return (
     <CardsExplorer>
-      {({ 
+      {({
         filtersVisible,
         setFiltersVisible,
       }) => (
         <>
-          <div ref={topMarkerRef}/>
+          <div ref={topMarkerRef} />
           <SearchHeader
             hasFilters
             filtersOpened={filtersVisible}
@@ -238,6 +325,7 @@ export const Marketplace = ({}: Props) => {
                   }
                 }
               }}
+              initialValue={urlQuery.search}
               className={styleSearch.large_search}
             />
           </SearchHeader>
@@ -252,7 +340,7 @@ export const Marketplace = ({}: Props) => {
               </FiltersPanel>
             )}
 
-            <div style={{width: "100%"}}>
+            <div style={{ width: "100%" }}>
               {filterTags.length > 0 && (
                 <>
                   <ExploreTags
@@ -263,7 +351,7 @@ export const Marketplace = ({}: Props) => {
                       setSortValue(sortBeforeSearch.current)
                     }}
                   />
-                  <Spacing size="regular"/>
+                  <Spacing size="regular" />
                 </>
               )}
 
@@ -274,7 +362,7 @@ export const Marketplace = ({}: Props) => {
               <InfiniteScrollTrigger onTrigger={infiniteScrollFetch} canTrigger={!!data && !loading}>
                 <CardsContainer>
                   {listings?.length > 0 && listings.map(offer => (
-                    <ObjktCard key={offer.id} objkt={offer.objkt}/>
+                    <ObjktCard key={offer.id} objkt={offer.objkt} />
                   ))}
                   {loading && (
                     <CardsLoading number={ITEMS_PER_PAGE} />

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -27,11 +27,11 @@ const App = ({ Component, pageProps }: AppPropsWithLayout) => {
   const router = useRouter()
   const retainedComponents = useRef<any>({})
 
-  const isRetainableRoute = ROUTES_TO_RETAIN.includes(router.asPath)
+  const isRetainableRoute = ROUTES_TO_RETAIN.includes(router.pathname)
 
   // if the current route is stored in memory and is loaded now, reset its index
-  if (retainedComponents.current[router.asPath]) {
-    retainedComponents.current[router.asPath].index = -1 // -1 because it will be incremented just after
+  if (retainedComponents.current[router.pathname]) {
+    retainedComponents.current[router.pathname].index = -1 // -1 because it will be incremented just after
   }
 
   // clear the retained component if they reach a threshold
@@ -44,12 +44,12 @@ const App = ({ Component, pageProps }: AppPropsWithLayout) => {
         delete retainedComponents.current[key]
       }
     }
-  }, [router.asPath])
+  }, [router.pathname])
 
   // Add Component to retainedComponents if we haven't got it already
-  if (isRetainableRoute && !retainedComponents.current[router.asPath]) {
+  if (isRetainableRoute && !retainedComponents.current[router.pathname]) {
     const MemoComponent = memo(Component)
-    retainedComponents.current[router.asPath] = {
+    retainedComponents.current[router.pathname] = {
       component: <MemoComponent {...pageProps} />,
       scrollPos: 0,
       index: 0
@@ -60,22 +60,22 @@ const App = ({ Component, pageProps }: AppPropsWithLayout) => {
   const handleRouteChangeStart = (url: any) => {
     // first we clear the existing retained components, so that only the last one remains
     if (isRetainableRoute) {
-      retainedComponents.current[router.asPath].scrollPos = window.scrollY
+      retainedComponents.current[router.pathname].scrollPos = window.scrollY
     }
   }
 
-  // Save scroll position - requires an up-to-date router.asPath
+  // Save scroll position - requires an up-to-date router.pathname
   useEffect(() => {
     router.events.on('routeChangeStart', handleRouteChangeStart)
     return () => {
       router.events.off('routeChangeStart', handleRouteChangeStart)
     }
-  }, [router.asPath])
+  }, [router.pathname])
 
   // Scroll to the saved position when we load a retained component
   useEffect(() => {
-    if (isRetainableRoute && retainedComponents.current[router.asPath]) {
-      window.scrollTo(0, retainedComponents.current[router.asPath].scrollPos)
+    if (isRetainableRoute && retainedComponents.current[router.pathname]) {
+      window.scrollTo(0, retainedComponents.current[router.pathname].scrollPos)
     }
   }, [Component, pageProps])
 
@@ -111,7 +111,7 @@ const App = ({ Component, pageProps }: AppPropsWithLayout) => {
               {Object.entries(retainedComponents.current).map(([path, c]: any) => (
                 <div
                   key={path}
-                  style={{ display: router.asPath === path ? 'block' : 'none' }}
+                  style={{ display: router.pathname === path ? 'block' : 'none' }}
                 >
                   {c.component}
                 </div>

--- a/src/pages/marketplace.tsx
+++ b/src/pages/marketplace.tsx
@@ -9,31 +9,31 @@ import { HeaderRanks } from '../components/Stats/HeaderRanks'
 
 
 
-const MarketplacePage: NextPage = () => {
+const MarketplacePage: NextPage = ({ query }: any) => {
   return (
     <>
       <Head>
         <title>fxhash — marketplace</title>
-        <meta key="og:title" property="og:title" content="fxhash — marketplace"/> 
-        <meta key="description" name="description" content="Collect and trade your NFTs generated on fxhash"/>
-        <meta key="og:description" property="og:description" content="Collect and trade your NFTs generated on fxhash"/>
-        <meta key="og:type" property="og:type" content="website"/>
-        <meta key="og:image" property="og:image" content="https://www.fxhash.xyz/images/og/og1.jpg"/>
+        <meta key="og:title" property="og:title" content="fxhash — marketplace" />
+        <meta key="description" name="description" content="Collect and trade your NFTs generated on fxhash" />
+        <meta key="og:description" property="og:description" content="Collect and trade your NFTs generated on fxhash" />
+        <meta key="og:type" property="og:type" content="website" />
+        <meta key="og:image" property="og:image" content="https://www.fxhash.xyz/images/og/og1.jpg" />
       </Head>
 
       <Spacing size="3x-large" />
-      
+
       <HeaderRanks>
-        <CollectionRanks/>
+        <CollectionRanks />
       </HeaderRanks>
-      
+
       <Spacing size="6x-large" />
 
       <section>
         <MarketplaceTabs active={0} />
 
         <ClientOnlyEmpty>
-          <Marketplace />
+          <Marketplace urlQuery={query} />
         </ClientOnlyEmpty>
       </section>
 
@@ -42,6 +42,11 @@ const MarketplacePage: NextPage = () => {
       <Spacing size="6x-large" />
     </>
   )
+}
+
+// get url parameters
+MarketplacePage.getInitialProps = async ({ query }) => {
+  return { query }
 }
 
 export default MarketplacePage


### PR DESCRIPTION
Now (on the marketplace page) all the search filter are added to the URL as parameters:


https://user-images.githubusercontent.com/3226096/164341893-0cf2ac9a-868c-43af-89c9-a4a4b9c04f31.mp4


The url can be shared and the filters will be restored when the page loads

There is still a small "bug" (also in production), when you search some text and then clear the filter, the text inside the input is not cleared:

https://user-images.githubusercontent.com/3226096/164342185-f9f45a63-3c05-4758-b3ca-6b47d04c0e28.mp4


