### PR TITLE
Show reserves progress bar in tokens cards in the explore page

### DIFF
--- a/src/containers/ExploreGenerativeTokens.tsx
+++ b/src/containers/ExploreGenerativeTokens.tsx
@@ -44,6 +44,9 @@ const Qu_genTokens = gql`
       enabled
       royalties
       createdAt
+      reserves {
+        amount
+      }
       ...Author
     }
   }
@@ -103,7 +106,7 @@ function sortValueToSortVariable(val: string) {
 interface Props {
 }
 
-export const ExploreGenerativeTokens = ({}: Props) => {
+export const ExploreGenerativeTokens = ({ }: Props) => {
   // sort variables
   const [sortValue, setSortValue] = useState<string>("mintOpensAt-desc")
   const sort = useMemo<Record<string, any>>(() => sortValueToSortVariable(
@@ -199,7 +202,7 @@ export const ExploreGenerativeTokens = ({}: Props) => {
     setFilters({
       ...filters,
       [filter]: value
-    })  
+    })
   }
 
   const removeFilter = (filter: string) => {
@@ -215,7 +218,7 @@ export const ExploreGenerativeTokens = ({}: Props) => {
   const filterTags = useMemo<ExploreTagDef[]>(() => {
     const tags: ExploreTagDef[] = []
     for (const key in filters) {
-      let value: string|null = null
+      let value: string | null = null
       let k: any = key
       // @ts-ignore
       if (filters[k] !== undefined) {
@@ -262,12 +265,12 @@ export const ExploreGenerativeTokens = ({}: Props) => {
 
   return (
     <CardsExplorer>
-      {({ 
+      {({
         filtersVisible,
         setFiltersVisible,
       }) => (
         <>
-          <div ref={topMarkerRef}/>
+          <div ref={topMarkerRef} />
           <SearchHeader
             hasFilters
             filtersOpened={filtersVisible}
@@ -309,7 +312,7 @@ export const ExploreGenerativeTokens = ({}: Props) => {
               </FiltersPanel>
             )}
 
-            <div style={{width: "100%"}}>
+            <div style={{ width: "100%" }}>
               {filterTags.length > 0 && (
                 <>
                   <ExploreTags
@@ -320,7 +323,7 @@ export const ExploreGenerativeTokens = ({}: Props) => {
                       setSortValue(sortBeforeSearch.current)
                     }}
                   />
-                  <Spacing size="regular"/>
+                  <Spacing size="regular" />
                 </>
               )}
 

--- a/src/containers/Generative/ExploreIncoming.tsx
+++ b/src/containers/Generative/ExploreIncoming.tsx
@@ -33,6 +33,9 @@ const Qu_genTokens = gql`
       lockEnd
       royalties
       createdAt
+      reserves {
+        amount
+      }
       ...Author
     }
   }
@@ -41,7 +44,7 @@ const Qu_genTokens = gql`
 interface Props {
 }
 
-export const ExploreIncomingTokens = ({}: Props) => {
+export const ExploreIncomingTokens = ({ }: Props) => {
   const settingsCtx = useContext(SettingsContext)
 
   // use to know when to stop loading

--- a/src/queries/user.ts
+++ b/src/queries/user.ts
@@ -64,6 +64,9 @@ export const Qu_userGenTokens = gql`
         lockEnd
         ...Author
         ...Pricing
+        reserves {
+          amount
+        }
       }
     }
   }


### PR DESCRIPTION
resolves #61 

(shows only the progress, not the numeric amount of reserves)
![20220425_213711_firefox_OQ8rbRPUVJ](https://user-images.githubusercontent.com/3226096/165165427-526385d8-e8cc-4465-b950-7d4f89c0ca52.png)

