### PR TITLE
Fix Enjoy Collection Feature

### DIFF
--- a/src/utils/objkt.ts
+++ b/src/utils/objkt.ts
@@ -11,6 +11,6 @@ export function getObjktUrl(objkt: Objkt): string {
  */
 export function gentkLiveUrl(gentk: Objkt): string {
   return ipfsGatewayUrl(
-    `${gentk.issuer.generativeUri}/?fxhash=${gentk.generationHash}`
+    `${gentk.metadata.generatorUri}/?fxhash=${gentk.metadata.iterationHash}`
   )
 }


### PR DESCRIPTION
I can obviously not say anything about the background of this issue. but as reported in discord the enjoy feature seems broken. 

<img width="1552" alt="Screenshot 2022-04-26 at 19 10 35" src="https://user-images.githubusercontent.com/1128485/165355406-44fbb6b2-da9e-45cb-850e-2cffbeec208e.png">

I fixed it by using the properties from the metadata of the selected token.

