### PR TITLE
add graphql for user entire collection

### DIFF
--- a/src/containers/Generative/Enjoy/GenerativeEnjoy.tsx
+++ b/src/containers/Generative/Enjoy/GenerativeEnjoy.tsx
@@ -1,18 +1,16 @@
 import style from "./GenerativeEnjoy.module.scss"
 import Link from "next/link"
 import cs from "classnames"
-import { GenerativeTokenWithCollection } from "../../../types/entities/GenerativeToken"
 import { ArtworkIframe } from "../../../components/Artwork/PreviewIframe"
 import { ipfsGatewayUrl } from "../../../services/Ipfs"
 import { UserBadge } from "../../../components/User/UserBadge"
-import { getGenerativeTokenUrl } from "../../../utils/generative-token"
 import { useEffect, useMemo, useRef, useState } from "react"
-import { shuffleArray } from "../../../utils/array"
 import { useAnimationFrame, useHasInterractedIn } from "../../../utils/hookts"
 import { Objkt } from "../../../types/entities/Objkt"
 import { gentkLiveUrl, getObjktUrl } from "../../../utils/objkt"
 import { Modal } from "../../../components/Utils/Modal"
 import { SliderWithText } from "../../../components/Input/SliderWithText"
+import { Loader } from "../../../components/Utils/Loader"
 
 const DEFAULT_TIME_PER_ITERATION_MS = 20000
 const TRANSITION_DURATION_MS = 3000
@@ -32,8 +30,14 @@ interface Props {
   tokens: Objkt[]
   backLink: string
   requestData?: () => void
+  loading?: boolean
 }
-export function GenerativeEnjoy({ tokens, backLink, requestData }: Props) {
+export function GenerativeEnjoy({ 
+  tokens, 
+  backLink, 
+  requestData,
+  loading,
+}: Props) {
   // ref to elements manipulated directly
   const barRef = useRef<HTMLDivElement>(null)
   const frameContainerRef = useRef<HTMLDivElement>(null)
@@ -130,10 +134,19 @@ export function GenerativeEnjoy({ tokens, backLink, requestData }: Props) {
       </header>
 
       <div 
-        className={cs(style.frame_container, style.hidden, { [style.is_empty]: tokens.length === 0 })}
+        className={cs(style.frame_container, style.hidden, { 
+          [style.is_empty]: tokens.length === 0 || loading
+        })}
         ref={frameContainerRef}
       >
-        {tokens.length > 0 ? (
+        {loading ? (
+          <div className={cs(style.empty)}>
+            <Loader
+              color="white"
+              size="small"
+            />
+          </div>
+        ):tokens.length > 0 ? (
           <ArtworkIframe
             url={gentkLiveUrl(selectedToken)}
             onLoaded={onIframeLoaded}

--- a/src/containers/Generative/Enjoy/GenerativeEnjoy.tsx
+++ b/src/containers/Generative/Enjoy/GenerativeEnjoy.tsx
@@ -78,15 +78,6 @@ export function GenerativeEnjoy({
     }
   }
 
-  // whenever the cursor changed, we load the next one
-  useEffect(() => {
-    if (tokens.length > 1) {
-      // also, preload the next piece
-      const toLoad = tokens[cursorShifted(1)]
-      fetch(ipfsGatewayUrl(toLoad.metadata?.artifactUri))
-    }
-  }, [cursor])
-
   useAnimationFrame((time, delta) => {
     if (!paused) {
       relativeTimer.current+= delta

--- a/src/containers/User/Enjoy/UserCollectionEnjoy.tsx
+++ b/src/containers/User/Enjoy/UserCollectionEnjoy.tsx
@@ -1,7 +1,7 @@
 import style from "./UserCollectionEnjoy.module.scss"
 import cs from "classnames"
 import { User } from "../../../types/entities/User"
-import { useEffect, useRef } from "react"
+import { useEffect, useMemo, useRef } from "react"
 import { useQuery } from "@apollo/client"
 import { Qu_userEntireCollection } from "../../../queries/user"
 import { Objkt } from "../../../types/entities/Objkt"
@@ -12,7 +12,7 @@ interface Props {
   user: User
 }
 export function UserCollectionEnjoy({
-  user
+  user,
 }: Props) {
   const { data, loading } = useQuery(Qu_userEntireCollection, {
     notifyOnNetworkStatusChange: true,
@@ -21,7 +21,15 @@ export function UserCollectionEnjoy({
     }
   })
 
-  const entireCollection: Objkt[]|null = data?.user.entireCollection || null
+  const entireCollection: Objkt[]|null = useMemo(
+    () => data?.user.entireCollection
+      ? data.user.entireCollection.map((gentk: Objkt) => ({
+        ...gentk,
+        owner: user,
+      }))
+      : null,
+    [data]
+  )
 
   return (
     <GenerativeEnjoy

--- a/src/containers/User/Enjoy/UserCollectionEnjoy.tsx
+++ b/src/containers/User/Enjoy/UserCollectionEnjoy.tsx
@@ -3,7 +3,7 @@ import cs from "classnames"
 import { User } from "../../../types/entities/User"
 import { useEffect, useRef } from "react"
 import { useQuery } from "@apollo/client"
-import { Qu_userObjkts } from "../../../queries/user"
+import { Qu_userEntireCollection } from "../../../queries/user"
 import { Objkt } from "../../../types/entities/Objkt"
 import { GenerativeEnjoy } from "../../Generative/Enjoy/GenerativeEnjoy"
 import { getUserProfileLink } from "../../../utils/user"
@@ -18,22 +18,20 @@ export function UserCollectionEnjoy({
   const currentLength = useRef<number>(0)
   const ended = useRef<boolean>(false)
 
-  const { data, loading, fetchMore } = useQuery(Qu_userObjkts, {
+  const { data, loading, fetchMore } = useQuery(Qu_userEntireCollection, {
     notifyOnNetworkStatusChange: true,
     variables: {
       id: user.id,
-      skip: 0,
-      take: 5
     }
   })
 
   useEffect(() => {
     if (!loading) {
-      if (currentLength.current === data.user.objkts?.length) {
+      if (currentLength.current === data.user.entireCollection?.length) {
         ended.current = true
       }
       else {
-        currentLength.current = data.user.objkts?.length
+        currentLength.current = data.user.entireCollection?.length
       }
     }
   }, [data, loading])
@@ -43,18 +41,16 @@ export function UserCollectionEnjoy({
       fetchMore({
         variables: {
           id: user.id,
-          skip: data?.user.objkts.length || 0,
-          take: 5
         }
       })
     }
   }
 
-  const objkts: Objkt[]|null = data?.user.objkts || null
+  const entireCollection: Objkt[]|null = data?.user.entireCollection || null
 
   return (
     <GenerativeEnjoy
-      tokens={objkts || []}
+      tokens={entireCollection || []}
       backLink={`${getUserProfileLink(user)}/collection`}
       requestData={load}
     />

--- a/src/containers/User/Enjoy/UserCollectionEnjoy.tsx
+++ b/src/containers/User/Enjoy/UserCollectionEnjoy.tsx
@@ -14,37 +14,12 @@ interface Props {
 export function UserCollectionEnjoy({
   user
 }: Props) {
-  // use to know when to stop loading
-  const currentLength = useRef<number>(0)
-  const ended = useRef<boolean>(false)
-
-  const { data, loading, fetchMore } = useQuery(Qu_userEntireCollection, {
+  const { data, loading } = useQuery(Qu_userEntireCollection, {
     notifyOnNetworkStatusChange: true,
     variables: {
       id: user.id,
     }
   })
-
-  useEffect(() => {
-    if (!loading) {
-      if (currentLength.current === data.user.entireCollection?.length) {
-        ended.current = true
-      }
-      else {
-        currentLength.current = data.user.entireCollection?.length
-      }
-    }
-  }, [data, loading])
-
-  const load = () => {
-    if (!ended.current) {
-      fetchMore({
-        variables: {
-          id: user.id,
-        }
-      })
-    }
-  }
 
   const entireCollection: Objkt[]|null = data?.user.entireCollection || null
 
@@ -52,7 +27,7 @@ export function UserCollectionEnjoy({
     <GenerativeEnjoy
       tokens={entireCollection || []}
       backLink={`${getUserProfileLink(user)}/collection`}
-      requestData={load}
+      loading={loading}
     />
   )
 }

--- a/src/queries/user.ts
+++ b/src/queries/user.ts
@@ -71,6 +71,39 @@ export const Qu_userGenTokens = gql`
     }
   }
 `
+export const Qu_userEntireCollection = gql`
+  ${Frag_GenAuthor}
+
+  query UserCollection(
+    $id: String!,
+  ) {
+    user(id: $id) {
+      id
+      entireCollection {
+        id
+        version
+        assigned
+        rarity
+        iteration
+        generationHash
+        metadata
+        issuer {
+          name
+          flag
+          generativeUri
+          ...Author
+        }
+        name
+        createdAt
+        activeListing {
+          id
+          version
+          price
+        }
+      }
+    }
+  }
+`
 
 export const Qu_userObjkts = gql`
   ${Frag_GenAuthor}

--- a/src/queries/user.ts
+++ b/src/queries/user.ts
@@ -86,7 +86,6 @@ export const Qu_userEntireCollection = gql`
         rarity
         iteration
         generationHash
-        metadata
         issuer {
           name
           flag


### PR DESCRIPTION
@ciphrd I implemented a separate `Qu_userEntireCollection` for the enjoy collection because `Qu_userObjkts` i also used in the normal user collection page and i guess there it makes sense to keep paginated objkts. let me know what you think

- fix #86