### PR TITLE
keep iframe history hidden on gentk variation

### DIFF
--- a/src/components/Artwork/PreviewIframe.tsx
+++ b/src/components/Artwork/PreviewIframe.tsx
@@ -33,16 +33,17 @@ export const ArtworkIframe = forwardRef<ArtworkIframeRef, Props>(({
   }, [])
 
   const reloadIframe = () => {
-    if (iframeRef.current) {
+    if (url && iframeRef?.current?.contentWindow) {
       setLoading(true)
       setError(false)
-      iframeRef.current.src = iframeRef.current.src
+      iframeRef.current.contentWindow.location.replace(url);
     }
   }
 
   useEffect(() => {
     // when the url changes, we set reload to true
     setLoading(true)
+    console.log(url)
     if (url && iframeRef?.current?.contentWindow) {
       // keep iframe history hidden
       iframeRef.current.contentWindow.location.replace(url);

--- a/src/components/Artwork/PreviewIframe.tsx
+++ b/src/components/Artwork/PreviewIframe.tsx
@@ -16,9 +16,9 @@ export interface ArtworkIframeRef {
   getHtmlIframe: () => HTMLIFrameElement | null
 }
 
-export const ArtworkIframe = forwardRef<ArtworkIframeRef, Props>(({ 
-  url, 
-  textWaiting, 
+export const ArtworkIframe = forwardRef<ArtworkIframeRef, Props>(({
+  url,
+  textWaiting,
   onLoaded,
   hasLoading = true,
 }, ref) => {
@@ -43,7 +43,11 @@ export const ArtworkIframe = forwardRef<ArtworkIframeRef, Props>(({
   useEffect(() => {
     // when the url changes, we set reload to true
     setLoading(true)
-  }, [url])
+    if (url && iframeRef?.current?.contentWindow) {
+      // keep iframe history hidden
+      iframeRef.current.contentWindow.location.replace(url);
+    }
+  }, [url, iframeRef])
 
   // set iframe state to loaded and set ref to loaded to prevent loader init to loading
   const setIframeLoaded = () => {
@@ -51,7 +55,7 @@ export const ArtworkIframe = forwardRef<ArtworkIframeRef, Props>(({
     setLoading(false)
   }
 
-  const getHtmlIframe = (): HTMLIFrameElement|null => {
+  const getHtmlIframe = (): HTMLIFrameElement | null => {
     return iframeRef.current
   }
 
@@ -64,7 +68,6 @@ export const ArtworkIframe = forwardRef<ArtworkIframeRef, Props>(({
     <div className={cs(style["iframe-container"])}>
       <iframe
         ref={iframeRef}
-        src={url}
         sandbox="allow-scripts allow-same-origin"
         className={cs(style.iframe)}
         onLoad={() => {

--- a/src/components/Artwork/PreviewIframe.tsx
+++ b/src/components/Artwork/PreviewIframe.tsx
@@ -36,17 +36,16 @@ export const ArtworkIframe = forwardRef<ArtworkIframeRef, Props>(({
     if (url && iframeRef?.current?.contentWindow) {
       setLoading(true)
       setError(false)
-      iframeRef.current.contentWindow.location.replace(url);
+      iframeRef.current.contentWindow.location.replace(url)
     }
   }
 
   useEffect(() => {
     // when the url changes, we set reload to true
     setLoading(true)
-    console.log(url)
     if (url && iframeRef?.current?.contentWindow) {
       // keep iframe history hidden
-      iframeRef.current.contentWindow.location.replace(url);
+      iframeRef.current.contentWindow.location.replace(url)
     }
   }, [url, iframeRef])
 


### PR DESCRIPTION
fixes #31 

Using `iframe.contentWindow.location.replace(newUrl)` doesn't add the iframe history to the main one!

_Source: https://html.spec.whatwg.org/multipage/iframe-embed-object.html#dom-iframe-contentwindow_