### PR TITLE
fix(collab-badge): randomize client-side only to avoid rehydration issues

### DIFF
--- a/src/components/User/CollabBadge.module.scss
+++ b/src/components/User/CollabBadge.module.scss
@@ -31,11 +31,11 @@
         font-size: var(--font-size-small);
       }
     }
-  
+
     .avatar {
       border: 3px solid var(--color-white);
     }
-  
+
     .link {
       background-color: var(--color-white);
       border-radius: 100px;
@@ -47,7 +47,7 @@
       padding: 0 16px;
       color: var(--color-gray);
       box-shadow: 0px 2px 8px -4px rgb(0 0 0 / 8%);
-  
+
       .caret {
         font-size: 0.8em;
       }
@@ -236,6 +236,10 @@
         }
       }
     }
+  }
+
+  &.hide {
+    opacity: 0;
   }
 }
 

--- a/src/components/User/CollabBadge.tsx
+++ b/src/components/User/CollabBadge.tsx
@@ -1,11 +1,10 @@
 import style from "./CollabBadge.module.scss"
-import colors from "../../styles/Colors.module.css"
 import badgeStyle from "./UserBadge.module.scss"
 import cs from "classnames"
 import { IProps as IEntityBadgeProps } from "./EntityBadge"
 import { Collaboration } from "../../types/entities/User"
 import { Avatar } from "./Avatar"
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { shuffleArray } from "../../utils/array"
 import { UserBadge } from "./UserBadge"
 import { getUserName, isUserVerified } from "../../utils/user"
@@ -14,24 +13,28 @@ interface Props extends IEntityBadgeProps {
   user: Collaboration
 }
 export function CollabBadge(props: Props) {
-  // extract from props
   const {
     user,
     size,
     toggeable = false,
     avatarSide,
   } = props
+  const [collaborators, setCollaborators] = useState(user.collaborators);
+  const [isInitialized, setIsInitialized] = useState(false);
 
-  const [opened, setOpened] = useState<boolean>(false)
-  const users = useMemo(() => shuffleArray(user.collaborators), [user])
-
+  const [opened, setOpened] = useState<boolean>(false);
+  useEffect(() => {
+    setCollaborators(stateArray => shuffleArray(stateArray));
+    setIsInitialized(true);
+  }, [])
   return (
     <div className={cs(
-      style.root, 
-      style[`size_${size}`], 
+      style.root,
+      style[`size_${size}`],
       style[`side_${avatarSide}`], {
         [style.opened]: opened,
         [style.toggeable]: toggeable,
+        [style.hide]: !isInitialized,
       }
     )}>
       <button
@@ -40,8 +43,8 @@ export function CollabBadge(props: Props) {
         onClick={() => setOpened(!opened)}
         disabled={!toggeable}
       >
-        {users.map(user => (
-          <div 
+        {collaborators.map(user => (
+          <div
             key={user.id}
             className={cs(style.avatar_wrapper)}
           >
@@ -57,8 +60,8 @@ export function CollabBadge(props: Props) {
               <span className={cs(style.user_name_content)}>
                 {getUserName(user, 10)}
                 {isUserVerified(user) && (
-                  <i 
-                    aria-hidden 
+                  <i
+                    aria-hidden
                     className={cs("fas", "fa-badge-check", style.verified)}
                   />
                 )}
@@ -66,7 +69,7 @@ export function CollabBadge(props: Props) {
             </span>
           </div>
         ))}
-        <div 
+        <div
           className={cs(
             badgeStyle.avatar,
             badgeStyle[`avatar-${size}`],
@@ -78,7 +81,7 @@ export function CollabBadge(props: Props) {
           <span>
             {toggeable ? (
               <>
-                <i 
+                <i
                   className={cs(
                     `fa-solid fa-angle-${opened?"up":"down"}`,
                     style.caret,
@@ -93,10 +96,10 @@ export function CollabBadge(props: Props) {
           </span>
         </div>
       </button>
-  
+
       {toggeable && (
         <div className={cs(style.collaborators)}>
-          {users.map(user => (
+          {collaborators.map(user => (
             <UserBadge
               key={user.id}
               {...props}

--- a/src/pages/gentk/[...params].tsx
+++ b/src/pages/gentk/[...params].tsx
@@ -48,7 +48,7 @@ const ObjktDetails: NextPage<Props> = ({ objkt }) => {
   const creator: User = objkt.issuer.author
   const settings = useContext(SettingsContext)
   // get the display url for og:image
-  const displayUrl = objkt.metadata?.displayUri 
+  const displayUrl = objkt.metadata?.displayUri
     && ipfsGatewayUrl(objkt.metadata?.displayUri)
   // used to run code if mode image is active
   const [running, setRunning] = useState<boolean>(false)
@@ -64,7 +64,7 @@ const ObjktDetails: NextPage<Props> = ({ objkt }) => {
     <>
       <Head>
         <title>fxhash — {objkt.name}</title>
-        <meta key="og:title" property="og:title" content={`${objkt.name} — fxhash`}/> 
+        <meta key="og:title" property="og:title" content={`${objkt.name} — fxhash`}/>
         <meta key="description" name="description" content={truncateEnd(objkt.metadata?.description || "", 200, "")}/>
         <meta key="og:description" property="og:description" content={truncateEnd(objkt.metadata?.description || "", 200, "")}/>
         <meta key="og:type" property="og:type" content="website"/>
@@ -84,13 +84,13 @@ const ObjktDetails: NextPage<Props> = ({ objkt }) => {
         <div className={cs(style.artwork_header_mobile, layout.break_words)}>
           <h3>{ objkt.name }</h3>
           <Spacing size="regular"/>
-          <UserBadge 
+          <UserBadge
             prependText="created by"
             user={creator}
             size="regular"
           />
           <Spacing size="2x-small"/>
-          <UserBadge 
+          <UserBadge
             prependText="owned by"
             user={owner}
             size="regular"
@@ -101,14 +101,14 @@ const ObjktDetails: NextPage<Props> = ({ objkt }) => {
         <div className={cs(layout.cols2, layout['responsive-reverse'])}>
           <div className={cs(style['presentation-details'])}>
             <div className={cs(style.artwork_header)}>
-              <EntityBadge 
+              <EntityBadge
                 prependText="created by"
                 user={creator}
                 size="big"
                 toggeable
               />
               <Spacing size="2x-small"/>
-              <UserBadge 
+              <UserBadge
                 prependText="owned by"
                 user={owner}
                 size="big"
@@ -121,7 +121,7 @@ const ObjktDetails: NextPage<Props> = ({ objkt }) => {
 
             <div className={cs(style.buttons)}>
               {objkt.activeListing && (
-                <Collect 
+                <Collect
                   listing={objkt.activeListing}
                   objkt={objkt}
                 />
@@ -135,7 +135,7 @@ const ObjktDetails: NextPage<Props> = ({ objkt }) => {
             </div>
 
             <Spacing size="regular"/>
-            
+
             <div className={cs(layout.buttons_inline, layout.flex_wrap)}>
               <Link href={getGenerativeTokenUrl(objkt.issuer)} passHref>
                 <Button isLink={true} size="regular">
@@ -186,7 +186,7 @@ const ObjktDetails: NextPage<Props> = ({ objkt }) => {
                 </>
               )}
               <strong>Operation hash</strong>
-              <a 
+              <a
                 target="_blank"
                 referrerPolicy="no-referrer"
                 href={`https://tzkt.io/${objkt.generationHash}`}
@@ -196,7 +196,7 @@ const ObjktDetails: NextPage<Props> = ({ objkt }) => {
               </a>
               <strong>Metadata</strong>
               {objkt.assigned ? (
-                <a 
+                <a
                   target="_blank"
                   referrerPolicy="no-referrer"
                   href={ipfsGatewayUrl(objkt.metadataUri)}
@@ -216,7 +216,7 @@ const ObjktDetails: NextPage<Props> = ({ objkt }) => {
                   {settings.quality === 0 && !running ? (
                     <img src={displayUrl} alt={`${objkt.name} preview`}/>
                   ):(
-                    <ArtworkIframe 
+                    <ArtworkIframe
                       ref={iframeRef}
                       url={gentkLiveUrl(objkt)}
                       hasLoading={false}
@@ -314,7 +314,7 @@ const ObjktDetails: NextPage<Props> = ({ objkt }) => {
 export const getServerSideProps: GetServerSideProps = async (context) => {
   let idStr,
       slug
-  
+
   if (context.params?.params && context.params.params[0]) {
     if (context.params.params[0] === "slug" && context.params.params[1]) {
       slug = context.params.params[1]


### PR DESCRIPTION
fix #105 

I encountered this kind of bug in the past, server-side shuffle and client-side shuffle have a different result which mix the results when rehydrating. 
A simple fix is to run the randomisation only on the client-side (using useEffect)