### PR TITLE
fixed reserveProgress calculation

### DIFF
--- a/src/components/Artwork/MintProgress.tsx
+++ b/src/components/Artwork/MintProgress.tsx
@@ -31,35 +31,36 @@ export function MintProgress({
   const minted = supply - balance
   const complete = balance === 0
 
-  const [progress, burntProgress, reserveSize, reserveProgress] = 
-  useMemo<[number, number, number, number]>(
-    () => {
-      const progress = minted / (settings.displayBurntCard ? originalSupply : supply)
-      const burnt = originalSupply - supply
-      const burntProgress = settings.displayBurntCard 
-        ? (burnt / originalSupply)
-        : 0
-      const reserveSize = token.reserves 
-        ? token.reserves.reduce((a, b) => a + b.amount, 0)
-        : 0
-      const reserveProgress = Math.min(
-        1, reserveSize/(originalSupply - burntProgress)
-      )
-      return [
-        progress,
-        burntProgress,
-        reserveSize,
-        reserveProgress,
-      ]
-    }
-  , [settings])
+  const [progress, burntProgress, reserveSize, reserveProgress] =
+    useMemo<[number, number, number, number]>(
+      () => {
+        const visibleSupply = (settings.displayBurntCard ? originalSupply : supply)
+        const progress = minted / visibleSupply
+        const burnt = originalSupply - supply
+        const burntProgress = settings.displayBurntCard
+          ? (burnt / originalSupply)
+          : 0
+        const reserveSize = token.reserves
+          ? token.reserves.reduce((a, b) => a + b.amount, 0)
+          : 0
+        const reserveProgress = Math.min(
+          1, reserveSize / visibleSupply
+        )
+        return [
+          progress,
+          burntProgress,
+          reserveSize,
+          reserveProgress,
+        ]
+      }
+      , [settings])
 
   // compute how many editions in reserve the user is eligible for
-  const eligibleFor = useMemo(() => 
+  const eligibleFor = useMemo(() =>
     user
-    ? reserveEligibleAmount(user as User, token)
-    : 0
-  , [user, token])
+      ? reserveEligibleAmount(user as User, token)
+      : 0
+    , [user, token])
 
   return (
     <div className={cs(style.container)}>
@@ -67,29 +68,29 @@ export function MintProgress({
         [style.minted]: complete,
       })}>
         <span>
-          <strong className={cs(colors.secondary)}>{minted}</strong>/{supply} minted 
-          {complete && <i aria-hidden className="fas fa-check-circle"/>}
+          <strong className={cs(colors.secondary)}>{minted}</strong>/{supply} minted
+          {complete && <i aria-hidden className="fas fa-check-circle" />}
         </span>
         {children}
       </span>
       <div className={cs(style.progress)}>
-        <div 
+        <div
           className={cs(style.bar)}
           style={{
-            width: progress*100 + '%'
+            width: progress * 100 + '%'
           }}
         />
         <div
           className={cs(style.bar_reserve)}
           style={{
-            left: progress*100 + '%',
-            width: reserveProgress*100 + "%"
+            left: progress * 100 + '%',
+            width: reserveProgress * 100 + "%"
           }}
         />
-        <div 
+        <div
           className={cs(style.bar_burnt)}
           style={{
-            width: burntProgress*100 + '%'
+            width: burntProgress * 100 + '%'
           }}
         />
       </div>

--- a/src/queries/generative-token.ts
+++ b/src/queries/generative-token.ts
@@ -38,6 +38,7 @@ export const Qu_genToken = gql`
 
 export const Qu_genTokenMarketplace = gql`
   ${Frag_GenAuthor}
+  ${Frag_GenReserves}
   query Query($id: Float, $slug: String) {
     generativeToken(id: $id, slug: $slug) {
       id
@@ -69,6 +70,7 @@ export const Qu_genTokenMarketplace = gql`
       }
       createdAt
       ...Author
+      ...Reserves
     }
   }
 `


### PR DESCRIPTION
![20220524_080956_firefox_uHgw5JhO9H](https://user-images.githubusercontent.com/3226096/169965845-7a366381-2f3e-4a1b-8b89-d4a656983710.png)

![20220524_080621_firefox_GZ54qUZJUs](https://user-images.githubusercontent.com/3226096/169965848-4b6e0797-a39d-4767-9195-9d0a6efdc71b.png)

reserve progress width was wrong when the burnt edition weren't shown

solves #155