### PR TITLE
Capture test now uses S3 presigned url directly

### DIFF
--- a/src/containers/MintGenerative/StepConfigureCapture.tsx
+++ b/src/containers/MintGenerative/StepConfigureCapture.tsx
@@ -29,7 +29,6 @@ export const StepConfigureCapture: StepComponent = ({ onNext, state }) => {
       gpu: false,
     }
   )
-
   const { data, loading, error, post } = 
     useFetch<TestPreviewResponse|TestPreviewErrorResponse>(
       `${process.env.NEXT_PUBLIC_API_EXTRACT}/extract`, { 
@@ -37,11 +36,12 @@ export const StepConfigureCapture: StepComponent = ({ onNext, state }) => {
         responseType: "json"
       }
     )
-
-  // extracts the test image base64 data from the response if any
-  const testImage = useMemo<string|null>(() => {
-    return (data && !loading && !error) ? (data as TestPreviewResponse).captureBase64 : null
-  }, [data])
+  
+  // extract the presigned URL from the response, if there's one
+  const testImage = useMemo(
+    () => (data && !error) ? (data as TestPreviewResponse).capture : null,
+    [data, error]
+  )
 
   const { data: previewData, loading: previewLoading, error: previewError, post: previewPost } = 
     useFetch<PreviewResponse|PreviewErrorResponse>(`${process.env.NEXT_PUBLIC_API_FILE_ROOT}/preview`,

--- a/src/types/Responses.ts
+++ b/src/types/Responses.ts
@@ -76,8 +76,8 @@ export enum TestPreviewError {
 }
 
 export interface TestPreviewResponse {
-  captureBase64: string
-  features?: Record<string, any>
+  capture: string
+  features?: string
 }
 
 export interface TestPreviewErrorResponse {


### PR DESCRIPTION
* resolves #177 