### PR TITLE
feature/articles Allow inline styles and links in image caption

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "is-hotkey": "^0.2.0",
     "is-mobile": "^3.0.0",
     "lodash.throttle": "^4.1.1",
+    "mdast-util-from-markdown": "^1.2.0",
     "nanoid": "^4.0.0",
     "next": "12.0.7",
     "nextjs-progressbar": "^0.0.13",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "is-mobile": "^3.0.0",
     "lodash.throttle": "^4.1.1",
     "mdast-util-from-markdown": "^1.2.0",
+    "mdast-util-to-markdown": "^1.3.0",
     "nanoid": "^4.0.0",
     "next": "12.0.7",
     "nextjs-progressbar": "^0.0.13",

--- a/src/components/NFTArticle/processor.ts
+++ b/src/components/NFTArticle/processor.ts
@@ -166,8 +166,9 @@ function createMathNode(node: any) {
   }
 }
 
-function markdownImageToFigure(node: any) {
-  console.log('->', node, fromMarkdown(node.title))
+function markdownImageToFigure(node: any, next: (children: any[]) => any) {
+  // covert md image title to caption md ast for figcaption
+  const captionMDast = fromMarkdown(node.title)?.children?.[0] as Node
   return { 
     type: "figure",
     children: [{
@@ -178,9 +179,7 @@ function markdownImageToFigure(node: any) {
       }],
     }, {
       type: "figcaption",
-      children: [{
-        text: node.alt
-      }]
+      children: next(captionMDast.children)
     }]
   }
 }
@@ -247,7 +246,6 @@ function convertSlateLeafDirectiveToMarkdown(
  * image in proper markdown
  */
 function figureToMarkdown(node: any, next: (children: any[]) => any) {
-  console.log(node)
   // create a regular image node
   const imageNode: any = {
     type: "image"
@@ -263,8 +261,6 @@ function figureToMarkdown(node: any, next: (children: any[]) => any) {
       type: 'paragraph', 
       children: mdastCaption
     }, {strong: '_', emphasis: '_'});
-    console.log(mdCaption)
-    imageNode.alt = mdCaption.trim();
     imageNode.title = mdCaption.trim();
   }
   // now do the same for the image element

--- a/src/components/NFTArticle/processor.ts
+++ b/src/components/NFTArticle/processor.ts
@@ -71,9 +71,6 @@ export const customNodes: CustomArticleElementsByType = {
 function remarkFxHashCustom(): import('unified').Transformer<import('mdast').Root, import('mdast').Root> {
   return (tree: Root) => {
     visit(tree, (node) => {
-      if(node.type === 'image') {
-	console.log(node)
-      }
       if (
         node.type === 'textDirective' ||
         node.type === 'leafDirective' ||

--- a/yarn.lock
+++ b/yarn.lock
@@ -3021,6 +3021,24 @@ mdast-util-from-markdown@^1.0.0:
     unist-util-stringify-position "^3.0.0"
     uvu "^0.5.0"
 
+mdast-util-from-markdown@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-1.2.0.tgz#84df2924ccc6c995dec1e2368b2b208ad0a76268"
+  integrity sha512-iZJyyvKD1+K7QX1b5jXdE7Sc5dtoTry1vzV28UZZe8Z1xVnB/czKntJ7ZAkG0tANqRnBF6p3p7GpU1y19DTf2Q==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    "@types/unist" "^2.0.0"
+    decode-named-character-reference "^1.0.0"
+    mdast-util-to-string "^3.1.0"
+    micromark "^3.0.0"
+    micromark-util-decode-numeric-character-reference "^1.0.0"
+    micromark-util-decode-string "^1.0.0"
+    micromark-util-normalize-identifier "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    unist-util-stringify-position "^3.0.0"
+    uvu "^0.5.0"
+
 mdast-util-gfm-autolink-literal@^1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-1.0.2.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3010,25 +3010,7 @@ mdast-util-find-and-replace@^2.0.0:
     unist-util-is "^5.0.0"
     unist-util-visit-parents "^4.0.0"
 
-mdast-util-from-markdown@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.2.0.tgz"
-  integrity sha512-iZJyyvKD1+K7QX1b5jXdE7Sc5dtoTry1vzV28UZZe8Z1xVnB/czKntJ7ZAkG0tANqRnBF6p3p7GpU1y19DTf2Q==
-  dependencies:
-    "@types/mdast" "^3.0.0"
-    "@types/unist" "^2.0.0"
-    decode-named-character-reference "^1.0.0"
-    mdast-util-to-string "^3.1.0"
-    micromark "^3.0.0"
-    micromark-util-decode-numeric-character-reference "^1.0.0"
-    micromark-util-decode-string "^1.0.0"
-    micromark-util-normalize-identifier "^1.0.0"
-    micromark-util-symbol "^1.0.0"
-    micromark-util-types "^1.0.0"
-    unist-util-stringify-position "^3.0.0"
-    uvu "^0.5.0"
-
-mdast-util-from-markdown@^1.2.0:
+mdast-util-from-markdown@^1.0.0, mdast-util-from-markdown@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-1.2.0.tgz#84df2924ccc6c995dec1e2368b2b208ad0a76268"
   integrity sha512-iZJyyvKD1+K7QX1b5jXdE7Sc5dtoTry1vzV28UZZe8Z1xVnB/czKntJ7ZAkG0tANqRnBF6p3p7GpU1y19DTf2Q==


### PR DESCRIPTION
This PR implements inline styles and links for image figcaption. I used the `title` attribute (instead of alt) of the markdown image for serialising the inline styles into a md string. The `alt` attribute should be a plain string because the alt attribute should also be used for a11y, it shouldn't contain inline styles or links. 

- fix #231 