### PR TITLE
use bulletOther option to avoid comments between lists

### DIFF
--- a/src/components/NFTArticle/processor/getMarkdownFromSlateEditorState.ts
+++ b/src/components/NFTArticle/processor/getMarkdownFromSlateEditorState.ts
@@ -79,7 +79,7 @@ export default async function getMarkdownFromSlateEditorState(slate: Node[] ) {
       .use(slateToRemark, {
         overrides: slateToRemarkTransformerOverrides,
       })
-      .use(stringify)
+      .use(stringify, { bulletOther: '-' })
     const ast = await processor.run({
       type: "root",
       children: slate,


### PR DESCRIPTION
- fix #296

markdown string looks like this when using bulletOther option:
<img width="1338" alt="Screenshot 2022-08-03 at 20 40 22" src="https://user-images.githubusercontent.com/1128485/182684955-5d6595dd-e6ef-49e1-bb2c-64786342fcdd.png">

