### PR TITLE
allow js modules in the sandbox

### DIFF
--- a/public/sandbox/worker.js
+++ b/public/sandbox/worker.js
@@ -1,6 +1,13 @@
 const cache = {}
 const referrers = {}
 
+async function fetchUrl(url, file) {
+  // Let the service worker decide on secure response
+  // headers, but set its body to the file blob.
+  const record = await fetch(url)
+  const options = /\.m?js([#?].*)?$/.test(file) ? {headers: {'content-type': 'text/javascript'}} : undefined
+  return new Response(record.body, options);
+}
 
 self.addEventListener("fetch", async (event) => {
   // get an ID from the request referrer url
@@ -18,11 +25,17 @@ self.addEventListener("fetch", async (event) => {
         // only fetch if there is a match in the cache
         if (!cache[id][path]) return null;
         
-        // Let the service worker decide on secure response
-        // headers, but set its body to the file blob.
-
-        const record = await fetch(cache[id][path].url);
-        return new Response(await record.body);
+	return await fetchUrl(cache[id][path].url, event.request.url)
+      }())
+    }
+  } else {
+    // check for js modules being requested because the referrer will differ
+    const cacheId = Object.keys(cache).pop()
+    const moduleName = event.request.url.split('/').pop()
+    // only fetch when module is part of cache
+    if(cacheId && moduleName && cache[cacheId][moduleName]) {
+      event.respondWith(async function() {
+	return await fetchUrl(cache[cacheId][moduleName].url, event.request.url)
       }())
     }
   }


### PR DESCRIPTION
- fix #246

set proper mimetype for js files and fetch module files if referrer differs but file is part of cache. 

If you don't have a js module project you can use this zip to test it:
[Archive.zip](https://github.com/fxhash/fxhash-website/files/9455112/Archive.zip)
