### PR TITLE
fix(article): remove entire nodes when deleting foward/backward for medias (figure) and table

### DIFF
--- a/src/components/NFTArticle/SlateEditor/Plugins/SlateConstraintsPlugin.ts
+++ b/src/components/NFTArticle/SlateEditor/Plugins/SlateConstraintsPlugin.ts
@@ -1,12 +1,70 @@
-import { Transforms } from "slate";
-import { EnhanceEditorWith } from "../../../../types/ArticleEditor/Editor";
+import { Editor, Element, NodeEntry, Range, Transforms } from "slate";
+import { EnhanceEditorWith, FxEditor } from "../../../../types/ArticleEditor/Editor";
+import { getArticleBlockDefinition } from "../Blocks";
+
+const removeFollowingBlock = (
+  editor: FxEditor,
+  currentChildrenIdx: number,
+  followingNode: NodeEntry<Element> | undefined,
+  isPrevious: boolean
+): boolean => {
+  if (followingNode && followingNode[1].length > 0) {
+    const [followingElement, followingPath] = followingNode;
+    if (followingElement) {
+      const blockDefinition = getArticleBlockDefinition(followingElement.type);
+      if (blockDefinition?.hasDeleteBehaviorRemoveBlock && followingPath[0] !== currentChildrenIdx) {
+        Transforms.delete(editor, { at: followingPath, hanging: true, reverse: isPrevious })
+        return true;
+      }
+    }
+  }
+  return false;
+}
 
 /**
  * Adds some constraints to the editor to prevent running into unprocesseable
  * states
  */
 export const withConstraints: EnhanceEditorWith = (editor) => {
-  const { normalizeNode, insertBreak } = editor
+  const { normalizeNode, deleteBackward, deleteForward } = editor
+
+  /**
+   * Editor remove the previous children node if enabled
+   */
+  editor.deleteBackward = (unit) => {
+    const { selection } = editor
+    if (selection && Range.isCollapsed(selection)) {
+      const currentNodeHighestIdx = selection.anchor?.path[0] || 0;
+      const prevNode = Editor.previous<Element>(editor, {
+        at: selection,
+        mode: 'highest',
+        match: (n) => !Editor.isEditor(n) && Element.isElement(n)
+      })
+      if (removeFollowingBlock(editor, currentNodeHighestIdx, prevNode, true)) {
+        return;
+      }
+    }
+    deleteBackward(unit);
+  }
+
+  /**
+   * Editor remove the next children node if enabled
+   */
+  editor.deleteForward = (unit) => {
+    const { selection } = editor
+    if (selection && Range.isCollapsed(selection)) {
+      const currentNodeHighestIdx = selection.anchor?.path[0] || 0;
+      const nextNode = Editor.next<Element>(editor, {
+        at: selection,
+        mode: 'highest',
+        match: (n) => !Editor.isEditor(n) && Element.isElement(n)
+      })
+      if (removeFollowingBlock(editor, currentNodeHighestIdx, nextNode, false)) {
+        return;
+      }
+    }
+    deleteForward(unit);
+  }
 
   editor.normalizeNode = (entry) => {
     const [node, path] = entry

--- a/src/components/NFTArticle/SlateEditor/Plugins/SlateMediaPlugin.ts
+++ b/src/components/NFTArticle/SlateEditor/Plugins/SlateMediaPlugin.ts
@@ -1,9 +1,9 @@
-import { BaseOperation, Descendant, Editor, Element, Node, Text, Transforms } from "slate"
+import { BaseOperation, Descendant, Editor, Element, Node, Point, Range, Text, Transforms } from "slate"
 import { EnhanceEditorWith, FxEditor } from "../../../../types/ArticleEditor/Editor";
 import { IEditorMediaFile } from "../../../../types/ArticleEditor/Image";
 import { arrayRemoveDuplicates } from "../../../../utils/array";
 import { ALL_TEXT_FORMATS } from "../index";
-import { isFormatActive } from "../utils";
+import { isFormatActive, lookupElementByType } from "../utils";
 import { imageDefinition } from "../../elements/Image/ImageDefinition";
 import { videoDefinition } from "../../elements/Video/VideoDefinition";
 
@@ -61,11 +61,29 @@ export const withMediaSupport: EnhanceEditorWith = (
   editor: Editor,
   onMediasUpdate: (medias: IEditorMediaFile[]) => void
 ): FxEditor => {
-  const { insertData, isVoid, normalizeNode, apply } = editor
+  const { insertData, isVoid, normalizeNode, apply, deleteBackward } = editor
 
   // make image nodes void nodes
   editor.isVoid = element =>
     mediaTypes.indexOf(element.type) > -1 ? true : isVoid(element)
+
+  /**
+   * Deleting empty figcaption don't delete the media
+   */
+  editor.deleteBackward = unit => {
+    const { selection } = editor
+    if (selection && Range.isCollapsed(selection)) {
+      const element = lookupElementByType(editor, 'figcaption');
+      if (element) {
+        const [, elementPath] = element
+        const start = Editor.start(editor, elementPath)
+        if (Point.equals(selection.anchor, start)) {
+          return
+        }
+      }
+    }
+    deleteBackward(unit)
+  }
 
   // when an operation is triggered, we check if the operation may have resulted
   // in a change of the medias list, and if so we trigger an update.

--- a/src/components/NFTArticle/elements/Figure/FigureDefinition.tsx
+++ b/src/components/NFTArticle/elements/Figure/FigureDefinition.tsx
@@ -16,6 +16,7 @@ export const figureDefinition: IArticleBlockDefinition<null> = {
   icon: null,
   render: FigureElement,
   hasUtilityWrapper: true,
+  hasDeleteBehaviorRemoveBlock: true,
   editAttributeComp: ({ element, onEdit }) => {
     const children = Node.elements(element)
     for (const [child] of children) {

--- a/src/components/NFTArticle/elements/Table/TableDefinition.tsx
+++ b/src/components/NFTArticle/elements/Table/TableDefinition.tsx
@@ -13,6 +13,7 @@ export const tableDefinition: IArticleBlockDefinition<null> = {
     </TableEditor>
   ),
   hasUtilityWrapper: true,
+  hasDeleteBehaviorRemoveBlock: true,
   instanciateElement: () => SlateTable.createTable(2, 2),
   preventAutofocusTrigger: true,
 }

--- a/src/containers/Article/Editor/AutosaveArticle.tsx
+++ b/src/containers/Article/Editor/AutosaveArticle.tsx
@@ -27,14 +27,14 @@ const _AutosaveArticle = ({
 
   const handleSaveDraft = useCallback((articleFormState: NFTArticleForm) => {
     setStatus('saving');
-    dispatch({
+/*    dispatch({
       type: 'save',
       payload: {
         id,
         articleForm: articleFormState,
         minted: isMinted,
       },
-    })
+    })*/
     console.log(articleFormState.body)
     setStatus('saved');
   }, [dispatch, id, isMinted])

--- a/src/types/ArticleEditor/BlockDefinition.ts
+++ b/src/types/ArticleEditor/BlockDefinition.ts
@@ -43,4 +43,5 @@ export interface IArticleBlockDefinition<InstanciateOpts> {
   // prevent the auto-focus trigger when creating the element
   preventAutofocusTrigger?: boolean
   insertBreakBehavior?: EBreakBehavior | InsertBreakFunction
+  hasDeleteBehaviorRemoveBlock?: boolean
 }


### PR DESCRIPTION
fix #354