### PR TITLE
Fix/article: card responsive

### DIFF
--- a/src/components/Card/CardNFTArticle.module.scss
+++ b/src/components/Card/CardNFTArticle.module.scss
@@ -150,6 +150,11 @@
 
   .infos_header {
     gap: $spacing-x-small;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .date {
+    margin-left: 0;
   }
 
   .title {

--- a/src/containers/Explore/ExploreArticles.module.scss
+++ b/src/containers/Explore/ExploreArticles.module.scss
@@ -7,8 +7,13 @@
 }
 
 .article {
-  margin-bottom: $spacing-3x-large;
+  margin-bottom: $spacing-x-large;
+
   &:last-child {
     margin-bottom: 0;
+  }
+
+  @media (max-width: $breakpoint-sm) {
+    margin-bottom: 20px;
   }
 }

--- a/src/pages/explore/articles.tsx
+++ b/src/pages/explore/articles.tsx
@@ -35,7 +35,7 @@ const ExploreRevealFeed: NextPage = () => {
 
         <ExploreTabs active={2} />
 
-        <main className={cs(layout['padding-big'])}>
+        <main>
           <ExploreArticles />
         </main>
       </section>


### PR DESCRIPTION
- fix #353 

Float the date of the article cards below the author. 

<img width="273" alt="Screenshot 2022-09-05 at 10 23 59" src="https://user-images.githubusercontent.com/1128485/188403451-1058fb25-e820-4b75-8d1b-078dc1b1dd56.png">

@ciphrd card witdth was already as the token cards. Shall we also respect the "gap between cards" user setting for the spacing between article cards?