### PR TITLE
fix(article): card nft article have buttons working as intended -> edit goes to article edit page, bin delete the local changes

### DIFF
--- a/src/components/Card/CardNFTArticle.module.scss
+++ b/src/components/Card/CardNFTArticle.module.scss
@@ -100,7 +100,7 @@
     padding: 8px 12px;
   }
 
-  button {
+  button, a {
     background-color: transparent;
     border: none;
     cursor: pointer;
@@ -124,7 +124,7 @@
     color: var(--color-white);
     background: var(--color-border);
 
-    button:hover {
+    button:hover, a:hover {
       color: var(--color-success);
     }
   }

--- a/src/components/Card/CardNFTArticle.tsx
+++ b/src/components/Card/CardNFTArticle.tsx
@@ -11,6 +11,7 @@ import Link from 'next/link';
 import { Tags } from '../Tags/Tags';
 import { ArticlesContext } from '../../context/Articles';
 import { getArticleUrl } from '../../utils/entities/articles';
+import { Button } from "../Button";
 
 interface CardNftArticleProps {
   className?: string
@@ -18,18 +19,16 @@ interface CardNftArticleProps {
   isDraft?: boolean
   article: NFTArticleInfos
   editionsOwned?: number
-  onDelete?: (id: string) => void
 }
 
-const _CardNftArticle = ({ 
+const _CardNftArticle = ({
   article,
   editionsOwned,
   isDraft,
   imagePriority,
-  onDelete,
-  className 
+  className
 }: CardNftArticleProps) => {
-  const { 
+  const {
     id,
     title,
     slug,
@@ -37,21 +36,24 @@ const _CardNftArticle = ({
     description,
     tags,
     author,
-    createdAt 
+    createdAt
   } = article
   const settings = useContext(SettingsContext)
   const thumbnailUrl = useMemo(() => thumbnailUri && ipfsGatewayUrl(thumbnailUri), [thumbnailUri])
   const dateCreatedAt = useMemo(() => new Date(createdAt), [createdAt])
   const urlArticle = isDraft ? `/article/editor/local/${id}` : getArticleUrl(article)
-  const { isEdited } = useContext(ArticlesContext)
+  const { isEdited, dispatch } = useContext(ArticlesContext)
 
-  const onClickDelete = useCallback<MouseEventHandler>((event) => {
+  const onClickDeleteLocal = useCallback<(confirmMsg: string) => MouseEventHandler>((confirmMsg) => (event) => {
     event.preventDefault()
     event.stopPropagation()
-    if (window.confirm?.("Do you really want to delete this article ? It will be removed from your browser memory.")) {
-      onDelete?.(id as string)
+    if (window.confirm?.(confirmMsg)) {
+      dispatch({
+        type: "delete",
+        payload: { id: id as string }
+      })
     }
-  }, [])
+  }, [dispatch, id])
 
   const edited = useMemo(() => isEdited(id as string), [isEdited, id])
 
@@ -68,7 +70,7 @@ const _CardNftArticle = ({
           <span>DRAFT (saved locally)</span>
           <button
             type="button"
-            onClick={onClickDelete}
+            onClick={onClickDeleteLocal("Do you really want to delete this article ? It will be removed from your browser memory.")}
           >
             <i className="fa-solid fa-trash" aria-hidden/>
           </button>
@@ -77,12 +79,19 @@ const _CardNftArticle = ({
       {!isDraft && edited && (
         <div className={cs(style.banner, style.banner_edition)}>
           <span>Unpublished changes</span>
-          <button
-            type="button"
-            onClick={onClickDelete}
-          >
-            <i className="fa-solid fa-pen-to-square" aria-hidden/>
-          </button>
+          <div>
+            <button
+              type="button"
+              onClick={onClickDeleteLocal("Do you want to remove the unpublished local changes made to this article ?")}
+            >
+              <i className="fa-solid fa-trash" aria-hidden/>
+            </button>
+            <Link href={`/article/editor/${article.id}/`} passHref>
+              <a>
+                <i className="fa-solid fa-pen-to-square" aria-hidden/>
+              </a>
+            </Link>
+          </div>
         </div>
       )}
       <div className={style.content}>

--- a/src/containers/Article/LocalArticles.tsx
+++ b/src/containers/Article/LocalArticles.tsx
@@ -35,13 +35,6 @@ const _LocalArticles = ({ classNameArticle, user }: LocalArticlesProps) => {
     }, [] as NFTArticleInfos[])
     .sort((articleA, articleB) => articleA.createdAt > articleB.createdAt ? -1 : 1), [articles, user])
 
-  const deleteArticle = useCallback((id: string) => {
-    dispatch({
-      type: "delete",
-      payload: { id }
-    })
-  }, [dispatch])
-
   return (
     <>
       <div className={style.container_button}>
@@ -60,7 +53,6 @@ const _LocalArticles = ({ classNameArticle, user }: LocalArticlesProps) => {
           key={article.id}
           className={classNameArticle}
           article={article}
-          onDelete={deleteArticle}
           isDraft
         />
       )}


### PR DESCRIPTION
Found a bug on the user/articles page, unpublished changes buttons trigger a on delete that does nothing.
This commit fix the button behavior (goes to page edition of the article), and add a new button to delete the unpublished changes.