### PR TITLE
Reset loaded state when image cid changes

### DIFF
--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -180,6 +180,7 @@ function ReactiveImage({
         cid: image.cid,
         highestWidth: width,
       }
+      if (loaded?.cid !== image.cid) setLoaded(false)
       setUrl(getImageApiUrl(image.cid, width))
     }
   }, [getViewportSpace, image, ipfsUri])


### PR DESCRIPTION
- fix #450 

we have to reset the loaded state when we load a new image.

![Kapture 2022-10-28 at 17 39 27](https://user-images.githubusercontent.com/1128485/198677847-8ed7f725-43d6-4a3f-83f5-73f1e769d25b.gif)
