### PR TITLE
fix error on users query due to wrong params

### DIFF
--- a/src/pages/article/editor/local/[id]/preview.tsx
+++ b/src/pages/article/editor/local/[id]/preview.tsx
@@ -45,9 +45,9 @@ const ArticlePreviewPage: NextPage<ArticlePreviewPageProps> = ({ origin }) => {
               id_in: article.form.royaltiesSplit.map(
                 (royalty) => royalty.address
               ),
-              skip: 0,
-              take: 500,
             },
+            skip: 0,
+            take: 500,
           },
         })
         const newArticle = generateNftArticleFromDraft(


### PR DESCRIPTION
@ciphrd wrong query params resultet in user query never being resolved and therefore the `royaltiesSplits` was always empty preventing the possibility to mint articles.  

mentioned in discord by ErikWestener:

> when possible can someone check errors on fxtext. A few folks are unable to mint new pieces, myself included.  Attempting on multiple browsers, clearing cache, etc. -- I know it's not much to go on but error is below. 
![image](https://user-images.githubusercontent.com/1128485/198872210-7a13030b-5c35-4182-9401-73e246430036.png)