### PR TITLE
fix: modal and portal get correct font-color

### DIFF
--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -6,7 +6,8 @@ body {
   padding: 0;
   margin: 0;
   font-family: "Fira Code", monospace;
-  background: white;
+  background: var(--color-white);
+  color: var(--color-black);
 }
 
 :root {


### PR DESCRIPTION
Modals and anything using portal wouldn't have their default color set to --color-black, meaning that they would still be default browser color when using dark-mode. This PR fix that