### PR TITLE
add link to notion presskit

### DIFF
--- a/src/containers/Footer/Footer.tsx
+++ b/src/containers/Footer/Footer.tsx
@@ -59,6 +59,9 @@ export function Footer() {
             <Link href="https://feedback.fxhash.xyz">
               <a target="_blank">Feature request</a>
             </Link>
+            <Link href="https://fxhash.notion.site/Press-kit-689f9fec091f43eea35970c80f172fec">
+              <a target="_blank">Press kit</a>
+            </Link>
             <Link href="/status">
               <a>
                 <IndexerStatusLabel


### PR DESCRIPTION
- fix #489 

for now we are linking to notion v1. 
we can create a design for a designated page that can be implemented in v2?