### PR TITLE
replace cover with useClickOutside hook

### DIFF
--- a/src/components/Input/Select.tsx
+++ b/src/components/Input/Select.tsx
@@ -45,7 +45,6 @@ export function Select({
   ...props
 }: Props) {
   const selectRef = useRef<HTMLDivElement>(null)
-  const buttonRef = useRef<HTMLDivElement>(null)
   const [searchString, setSearchString] = useState<string>("")
   const searcherRef = useRef<FuzzySearchType<any> | null>(null)
   const [searchResults, setSearchResults] = useState<IOptions[] | null>(null)
@@ -116,7 +115,6 @@ export function Select({
   // what are the options displayed ?
   const displayOptions = searchResults || options
 
-
   useClickOutside(selectRef, () => setOpened(false), false)
 
   return (
@@ -126,7 +124,6 @@ export function Select({
         ref={selectRef}
       >
         <button
-          ref={buttonRef}
           className={cs(style.select, className, { [style.opened]: opened })}
           onClick={toggleOpened}
           type="button"

--- a/src/components/Input/Select.tsx
+++ b/src/components/Input/Select.tsx
@@ -12,7 +12,7 @@ import { Cover } from "../Utils/Cover"
 import { useClientAsyncEffect } from "../../utils/hookts"
 import { InputText } from "./InputText"
 import type FuzzySearchType from "fuzzy-search"
-
+import useClickOutside from "hooks/useClickOutside"
 export interface IOptions {
   label: string
   value: any
@@ -45,6 +45,7 @@ export function Select({
   ...props
 }: Props) {
   const selectRef = useRef<HTMLDivElement>(null)
+  const buttonRef = useRef<HTMLDivElement>(null)
   const [searchString, setSearchString] = useState<string>("")
   const searcherRef = useRef<FuzzySearchType<any> | null>(null)
   const [searchResults, setSearchResults] = useState<IOptions[] | null>(null)
@@ -115,6 +116,9 @@ export function Select({
   // what are the options displayed ?
   const displayOptions = searchResults || options
 
+
+  useClickOutside(selectRef, () => setOpened(false), false)
+
   return (
     <>
       <div
@@ -122,6 +126,7 @@ export function Select({
         ref={selectRef}
       >
         <button
+          ref={buttonRef}
           className={cs(style.select, className, { [style.opened]: opened })}
           onClick={toggleOpened}
           type="button"
@@ -176,9 +181,6 @@ export function Select({
           </div>
         )}
       </div>
-      {opened && (
-        <Cover onClick={() => setOpened(false)} opacity={0} index={10} />
-      )}
     </>
   )
 }

--- a/src/components/Input/Select.tsx
+++ b/src/components/Input/Select.tsx
@@ -8,11 +8,11 @@ import {
   useRef,
   useEffect,
 } from "react"
-import { Cover } from "../Utils/Cover"
 import { useClientAsyncEffect } from "../../utils/hookts"
 import { InputText } from "./InputText"
 import type FuzzySearchType from "fuzzy-search"
 import useClickOutside from "hooks/useClickOutside"
+
 export interface IOptions {
   label: string
   value: any
@@ -115,7 +115,7 @@ export function Select({
   // what are the options displayed ?
   const displayOptions = searchResults || options
 
-  useClickOutside(selectRef, () => setOpened(false), false)
+  useClickOutside(selectRef, () => setOpened(false), !opened)
 
   return (
     <>


### PR DESCRIPTION
- fix #503 

We are using a `<Cover />` component when select is open that handles closing the open select dialog when you click anywhere. Since the `<Cover />` lays ontop of the scrollable area the scroll event doesn't arrive in the scrollable container. 

I removed the `Cover` from the `Select` component and replaced it with the `clickOutsideHook` 