### PR TITLE
presskit page: fix issue where router change to root tab would be ignored

### DIFF
--- a/src/containers/Presskit/Page.tsx
+++ b/src/containers/Presskit/Page.tsx
@@ -86,9 +86,9 @@ const PressKitPage = ({ tab }: PagePressKitProps) => {
     [handleChangeTab]
   )
   useEffect(() => {
-    if (!router?.query?.slug?.[0]) return
-    if (router.query.slug[0] !== activeTab)
-      setActiveTab(router.query.slug[0] as PressKitTabKey)
+    const nextTab = router?.query?.slug?.[0] || "fxhash"
+    if (nextTab === activeTab) return
+    setActiveTab(nextTab as PressKitTabKey)
   }, [router.query, activeTab, handleChangeTab])
   const Component = tabs[activeTab] ? tabs[activeTab].component : null
   const tabLabel = pressKitTabLabel[activeTab]


### PR DESCRIPTION
When navigating through the presskit tabs, the effect wouldn't recognise if the user would navigate to the "root" tab via back buttons of the browser because in that case the slug is undefined and the effect would be skipped.

