### PR TITLE
Fix: Collaborator badges overflowing Objkt card

### DIFF
--- a/src/components/User/CollabBadge.module.scss
+++ b/src/components/User/CollabBadge.module.scss
@@ -256,6 +256,10 @@
     .avatars {
       flex-direction: row;
 
+      .link:first-of-type {
+        z-index: 1;
+      }
+
       .link:last-of-type {
         display: none;
       }
@@ -273,10 +277,7 @@
 
         .avatar_wrapper {
           margin-left: -20px;
-
-          &:last-child {
-            margin-left: 0;
-          }
+          flex-direction: inherit;
         }
       }
 
@@ -286,7 +287,7 @@
           .user_name {
             margin-left: 10px;
             position: relative;
-            margin-right: -30px;
+            margin-right: -33px;
             width: auto;
           }
         }

--- a/src/components/User/CollabBadge.module.scss
+++ b/src/components/User/CollabBadge.module.scss
@@ -43,7 +43,7 @@
       position: relative;
 
       &:not(:first-child) {
-        margin-left: -28px;
+        margin-left: -25px;
       }
 
       .user_name {
@@ -210,17 +210,13 @@
       .avatars {
 
         .overflow_counter {
-          margin-right: -15px;
+          margin-right: -27px;
         }
         .avatars_list {
           margin-left: 37px;
         }
         .avatar_wrapper {
           margin-left: -37px;
-  
-          &.link {
-            margin-left: -75px;
-          }
         }
 
       }

--- a/src/components/User/CollabBadge.module.scss
+++ b/src/components/User/CollabBadge.module.scss
@@ -5,8 +5,6 @@
   .overflow_counter {
     transition: all 0.3s;
     display: flex;
-    margin-left: -25px !important;
-    margin-right: 10px;
     word-break: keep-all;
     padding: 5px 0 5px 6px;
     align-items: center;
@@ -256,12 +254,33 @@
   //
   &.side_right {
     .avatars {
-      flex-direction: row-reverse;
+      flex-direction: row;
+
+      .link:last-of-type {
+        display: none;
+      }
+
+      .overflow_counter {
+        margin-left: 0;
+        border: none;
+        padding-right: 0;
+        padding-left: 6px;
+      }
+
+
+      .avatars_list {
+        flex-direction: row-reverse;
+
+        .avatar_wrapper {
+          margin-left: -20px;
+
+          &:last-child {
+            margin-left: 0;
+          }
+        }
+      }
 
       .avatar_wrapper {
-        flex-direction: row-reverse;
-        margin-left: 0;
-        margin-right: -20px;
 
         &:not(.link):hover {
           .user_name {

--- a/src/components/User/CollabBadge.module.scss
+++ b/src/components/User/CollabBadge.module.scss
@@ -289,6 +289,7 @@
             position: relative;
             margin-right: -33px;
             width: auto;
+            line-height: 0.8em;
           }
         }
       }

--- a/src/components/User/CollabBadge.module.scss
+++ b/src/components/User/CollabBadge.module.scss
@@ -22,6 +22,7 @@
     .overflow_counter {
       display: flex;
       margin-left: 25px;
+      word-break: keep-all;
     }
 
     .avatar_wrapper {

--- a/src/components/User/CollabBadge.module.scss
+++ b/src/components/User/CollabBadge.module.scss
@@ -1,10 +1,6 @@
 @import "../../styles/Variables";
 
 .root {
-  padding-bottom: 20px;
-  @media (max-width: $breakpoint-sm) {
-    padding-bottom: 10px;
-  }
   
   .overflow_counter {
     transition: all 0.3s;
@@ -138,6 +134,11 @@
   }
 
   &.toggeable {
+    padding-bottom: 20px;
+    @media (max-width: $breakpoint-sm) {
+      padding-bottom: 10px;
+    }
+    
     .avatars {
       pointer-events: all;
     }

--- a/src/components/User/CollabBadge.module.scss
+++ b/src/components/User/CollabBadge.module.scss
@@ -76,9 +76,6 @@
 
   &.opened {
     .avatars {
-      .overflow_counter {
-        margin-right: -15px;
-      }
       .avatars_list {
         margin-left: 50px;
       }
@@ -86,7 +83,15 @@
         margin-left: -50px;
 
         &.link {
-          margin-left: -75px;
+          margin-left: -50px;
+        }
+
+        &.overflow_counter {
+          margin-right: -35px;
+        }
+
+        &.link.toggler {
+          margin-left: -30px;
         }
       }
     }
@@ -139,6 +144,10 @@
 
     .avatars {
       pointer-events: all;
+    }
+
+    .link.toggler {
+      margin-left: -10px;
     }
   }
 
@@ -208,13 +217,13 @@
       .avatars {
 
         .overflow_counter {
-          margin-right: -27px;
+          margin-right: -35px;
         }
         .avatars_list {
-          margin-left: 37px;
+          margin-left: 35px;
         }
         .avatar_wrapper {
-          margin-left: -37px;
+          margin-left: -33px;
         }
 
       }

--- a/src/components/User/CollabBadge.module.scss
+++ b/src/components/User/CollabBadge.module.scss
@@ -19,6 +19,11 @@
       }
     }
 
+    .overflow_counter {
+      display: flex;
+      margin-left: 25px;
+    }
+
     .avatar_wrapper {
       transition: all 0.3s;
       position: relative;

--- a/src/components/User/CollabBadge.module.scss
+++ b/src/components/User/CollabBadge.module.scss
@@ -138,7 +138,7 @@
     @media (max-width: $breakpoint-sm) {
       padding-bottom: 10px;
     }
-    
+
     .avatars {
       pointer-events: all;
     }
@@ -192,14 +192,9 @@
     align-items: flex-start !important;
     
     .avatars {
-      margin-left: 20px;
 
       .avatar {
         border-width: 2px;  
-      }
-
-      .avatar_wrapper {
-        margin-left: -20px;
       }
 
       .link {

--- a/src/components/User/CollabBadge.module.scss
+++ b/src/components/User/CollabBadge.module.scss
@@ -1,6 +1,29 @@
 @import "../../styles/Variables";
 
 .root {
+  padding-bottom: 20px;
+  @media (max-width: $breakpoint-sm) {
+    padding-bottom: 10px;
+  }
+  
+  .overflow_counter {
+    transition: all 0.3s;
+    display: flex;
+    margin-left: -25px !important;
+    margin-right: 10px;
+    word-break: keep-all;
+    padding: 5px 0 5px 6px;
+    align-items: center;
+    justify-content: flex-end;
+  }
+
+  .avatars_list {
+    transition: all 0.3s;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+
   .avatars {
     display: flex;
     flex-direction: row;
@@ -17,12 +40,6 @@
       .link {
         color: var(--color-black);
       }
-    }
-
-    .overflow_counter {
-      display: flex;
-      margin-left: 25px;
-      word-break: keep-all;
     }
 
     .avatar_wrapper {
@@ -65,8 +82,18 @@
 
   &.opened {
     .avatars {
-      .avatar_wrapper:not(:first-child) {
+      .overflow_counter {
+        margin-right: -15px;
+      }
+      .avatars_list {
+        margin-left: 50px;
+      }
+      .avatar_wrapper {
         margin-left: -50px;
+
+        &.link {
+          margin-left: -75px;
+        }
       }
     }
   }
@@ -76,19 +103,17 @@
     flex-direction: column;
     gap: 4px;
     font-size: var(--font-size-small);
-    margin-top: 0;
+    margin-top: -20px;
     margin-left: 3px;
     transition: all 0.3s;
     pointer-events: none;
     position: relative;
     align-items: flex-start;
+
     .collaborator {
       margin-top: -40px;
       opacity: 0;
       transition: all 0.3s ease-out;
-      @media (max-width: $breakpoint-sm) {
-        margin-top: -50px;
-      }
     }
   }
 
@@ -163,15 +188,17 @@
   // size related stuff
   //
   &.size_regular {
+    align-items: flex-start !important;
+    
     .avatars {
+      margin-left: 20px;
+
       .avatar {
-        border-width: 2px;
+        border-width: 2px;  
       }
 
       .avatar_wrapper {
-        &:not(:first-child) {
-          margin-left: -20px;
-        }
+        margin-left: -20px;
       }
 
       .link {
@@ -185,9 +212,21 @@
 
     &.opened {
       .avatars {
-        .avatar_wrapper:not(:first-child) {
-          margin-left: -37px;
+
+        .overflow_counter {
+          margin-right: -15px;
         }
+        .avatars_list {
+          margin-left: 37px;
+        }
+        .avatar_wrapper {
+          margin-left: -37px;
+  
+          &.link {
+            margin-left: -75px;
+          }
+        }
+
       }
     }
   }
@@ -199,9 +238,7 @@
       }
 
       .avatar_wrapper {
-        &:not(:first-child) {
-          margin-left: -10px;
-        }
+        margin-left: -10px;
       }
 
       .link {
@@ -215,7 +252,7 @@
 
     &.opened {
       .avatars {
-        .avatar_wrapper:not(:first-child) {
+        .avatar_wrapper {
           margin-left: -37px;
         }
       }
@@ -231,11 +268,8 @@
 
       .avatar_wrapper {
         flex-direction: row-reverse;
-
-        &:not(:first-child) {
-          margin-left: 0;
-          margin-right: -20px;
-        }
+        margin-left: 0;
+        margin-right: -20px;
 
         &:not(.link):hover {
           .user_name {

--- a/src/components/User/CollabBadge.tsx
+++ b/src/components/User/CollabBadge.tsx
@@ -53,6 +53,20 @@ export function CollabBadge(props: Props) {
         onClick={() => setOpened(!opened)}
         disabled={!toggeable}
       >
+        {!toggeable && (
+          <div
+            className={cs(
+              badgeStyle.avatar,
+              badgeStyle[`avatar-${size}`],
+              style.avatar,
+              style.avatar_wrapper,
+              style.link
+            )}
+          >
+            <i className="fa-solid fa-link" aria-hidden />
+          </div>
+        )}
+
         <div className={cs(style.avatars_list)}>
           {collaborators.slice(0, collaboratorsLimit).map((user) => (
             <div key={user.id} className={cs(style.avatar_wrapper)}>

--- a/src/components/User/CollabBadge.tsx
+++ b/src/components/User/CollabBadge.tsx
@@ -54,36 +54,50 @@ export function CollabBadge(props: Props) {
         onClick={() => setOpened(!opened)}
         disabled={!toggeable}
       >
+        <div className={cs(style.avatars_list)}>
+          {collaborators.slice(0, collaboratorsLimit).map((user) => (
+            <div key={user.id} className={cs(style.avatar_wrapper)}>
+              <Avatar
+                image={user.avatarMedia}
+                uri={user.avatarUri}
+                className={cs(
+                  badgeStyle.avatar,
+                  badgeStyle[`avatar-${size}`],
+                  style.avatar,
+                  classNameAvatar
+                )}
+              />
+              <span className={cs(style.user_name)}>
+                <span className={cs(style.user_name_content)}>
+                  {getUserName(user, 10)}
+                  {isUserVerified(user) && (
+                    <i
+                      aria-hidden
+                      className={cs("fas", "fa-badge-check", style.verified)}
+                    />
+                  )}
+                </span>
+              </span>
+            </div>
+          ))}
+        </div>
+
         {collaborators.length > collaboratorsLimit && (
-          <div className={cs(style.overflow_counter, colors["gray-dark"])}>
+          <div
+            className={cs(
+              style.overflow_counter,
+              colors["gray-dark"],
+              badgeStyle.avatar,
+              badgeStyle[`avatar-${size}`],
+              style.avatar,
+              style.avatar_wrapper,
+              style.link
+            )}
+          >
             +{collaborators.length - collaboratorsLimit}
           </div>
         )}
-        {collaborators.slice(0, collaboratorsLimit).map((user) => (
-          <div key={user.id} className={cs(style.avatar_wrapper)}>
-            <Avatar
-              image={user.avatarMedia}
-              uri={user.avatarUri}
-              className={cs(
-                badgeStyle.avatar,
-                badgeStyle[`avatar-${size}`],
-                style.avatar,
-                classNameAvatar
-              )}
-            />
-            <span className={cs(style.user_name)}>
-              <span className={cs(style.user_name_content)}>
-                {getUserName(user, 10)}
-                {isUserVerified(user) && (
-                  <i
-                    aria-hidden
-                    className={cs("fas", "fa-badge-check", style.verified)}
-                  />
-                )}
-              </span>
-            </span>
-          </div>
-        ))}
+
         <div
           className={cs(
             badgeStyle.avatar,

--- a/src/components/User/CollabBadge.tsx
+++ b/src/components/User/CollabBadge.tsx
@@ -25,6 +25,7 @@ export function CollabBadge(props: Props) {
   } = props
   const [collaborators, setCollaborators] = useState(user.collaborators)
   const [isInitialized, setIsInitialized] = useState(false)
+  const collaboratorsLimit = 3
 
   const [opened, setOpened] = useState<boolean>(false)
   useEffect(() => {
@@ -52,7 +53,7 @@ export function CollabBadge(props: Props) {
         onClick={() => setOpened(!opened)}
         disabled={!toggeable}
       >
-        {collaborators.map((user) => (
+        {collaborators.slice(0, collaboratorsLimit).map((user) => (
           <div key={user.id} className={cs(style.avatar_wrapper)}>
             <Avatar
               image={user.avatarMedia}

--- a/src/components/User/CollabBadge.tsx
+++ b/src/components/User/CollabBadge.tsx
@@ -1,6 +1,5 @@
 import style from "./CollabBadge.module.scss"
 import badgeStyle from "./UserBadge.module.scss"
-import colors from "../../styles/Colors.module.css"
 import cs from "classnames"
 import { IProps as IEntityBadgeProps } from "./EntityBadge"
 import { Collaboration } from "../../types/entities/User"
@@ -86,7 +85,6 @@ export function CollabBadge(props: Props) {
           <div
             className={cs(
               style.overflow_counter,
-              colors["gray-dark"],
               badgeStyle.avatar,
               badgeStyle[`avatar-${size}`],
               style.avatar,

--- a/src/components/User/CollabBadge.tsx
+++ b/src/components/User/CollabBadge.tsx
@@ -1,5 +1,6 @@
 import style from "./CollabBadge.module.scss"
 import badgeStyle from "./UserBadge.module.scss"
+import colors from "../../styles/Colors.module.css"
 import cs from "classnames"
 import { IProps as IEntityBadgeProps } from "./EntityBadge"
 import { Collaboration } from "../../types/entities/User"
@@ -53,6 +54,11 @@ export function CollabBadge(props: Props) {
         onClick={() => setOpened(!opened)}
         disabled={!toggeable}
       >
+        {collaborators.length > collaboratorsLimit && (
+          <div className={cs(style.overflow_counter, colors["gray-dark"])}>
+            +{collaborators.length - collaboratorsLimit}
+          </div>
+        )}
         {collaborators.slice(0, collaboratorsLimit).map((user) => (
           <div key={user.id} className={cs(style.avatar_wrapper)}>
             <Avatar

--- a/src/components/User/CollabBadge.tsx
+++ b/src/components/User/CollabBadge.tsx
@@ -112,6 +112,7 @@ export function CollabBadge(props: Props) {
 
         <div
           className={cs(
+            style.toggler,
             badgeStyle.avatar,
             badgeStyle[`avatar-${size}`],
             style.avatar,


### PR DESCRIPTION
The PR fixes #546.

The changes only address the bug so it’s no longer breaking the layout. 

The nice-to-have part to show the full list of collaborators from the card will be addressed in a separate PR as a feature.

**Current issue:**

![Screenshot 2023-01-20 at 16 26 34](https://user-images.githubusercontent.com/136504/213751531-22ea0f90-4942-4876-812c-a01132d7e3bb.png)

**After the fix:**

![Screenshot 2023-01-20 at 16 25 26](https://user-images.githubusercontent.com/136504/213751255-2dd838ab-1855-461a-bbb2-33fe46dcdd77.png)


