### PR TITLE
fix word break for DisplayTezos on narrow devices

### DIFF
--- a/src/components/Display/DisplayTezos.module.scss
+++ b/src/components/Display/DisplayTezos.module.scss
@@ -1,3 +1,3 @@
 .root {
-  
+  word-break: normal;
 }

--- a/src/components/GenerativeToken/MintController.module.scss
+++ b/src/components/GenerativeToken/MintController.module.scss
@@ -39,6 +39,7 @@
     display: flex;
     flex-direction: row;
     justify-content: space-between;
+    align-items: center;
     flex: 1;
   }
 }


### PR DESCRIPTION
before:
<img width="298" alt="image" src="https://user-images.githubusercontent.com/4563781/220394716-79956797-70c6-4616-9d10-1cfc3df8a015.png">

after:
<img width="288" alt="image" src="https://user-images.githubusercontent.com/4563781/220394786-1c7e4181-f764-4026-877a-0202b2e0e5e9.png">
