### PR TITLE
Revert/token version primary key

### DIFF
--- a/src/pages/generative/[id]/enjoy.tsx
+++ b/src/pages/generative/[id]/enjoy.tsx
@@ -97,7 +97,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       const { data, error } = await apolloClient.query({
         query: gql`
           ${Frag_UserBadge}
-          query Query($id: TokenId!) {
+          query Query($id: Float!) {
             generativeToken(id: $id) {
               id
               name

--- a/src/queries/generative-token.ts
+++ b/src/queries/generative-token.ts
@@ -19,7 +19,7 @@ export const Qu_genToken = gql`
   ${Frag_GenArticleMentions}
   ${Frag_GenTokenMintTickets}
 
-  query Query($id: TokenId, $slug: String) {
+  query Query($id: Float, $slug: String) {
     generativeToken(id: $id, slug: $slug) {
       ...TokenInfo
       tags
@@ -109,7 +109,7 @@ export const Qu_genTokensReported = gql`
 export const Qu_genTokenMarketplace = gql`
   ${Frag_GenTokenInfo}
   ${Frag_GenReserves}
-  query Query($id: TokenId, $slug: String) {
+  query Query($id: Float, $slug: String) {
     generativeToken(id: $id, slug: $slug) {
       ...TokenInfo
       moderationReason
@@ -139,7 +139,7 @@ export const Qu_genTokenIterations = gql`
   ${Frag_MediaImage}
   ${Frag_UserBadge}
   query GenerativeTokenIterations(
-    $id: TokenId
+    $id: Float
     $take: Int
     $skip: Int
     $sort: ObjktsSortInput
@@ -184,7 +184,7 @@ export const Qu_genTokenIterations = gql`
 
 export const Qu_genTokenAllIterations = gql`
   ${Frag_MediaImage}
-  query GenerativeTokenIterations($id: TokenId!) {
+  query GenerativeTokenIterations($id: Float!) {
     generativeToken(id: $id) {
       id
       entireCollection {
@@ -202,7 +202,7 @@ export const Qu_genTokenAllIterations = gql`
 `
 
 export const Qu_genTokenFeatures = gql`
-  query GenerativeTokenFeatures($id: TokenId) {
+  query GenerativeTokenFeatures($id: Float) {
     generativeToken(id: $id) {
       features
     }
@@ -211,7 +211,7 @@ export const Qu_genTokenFeatures = gql`
 
 export const Qu_genTokenMarketHistory = gql`
   query GenerativeTokenMarketHistory(
-    $id: TokenId
+    $id: Float
     $filters: MarketStatsHistoryInput!
   ) {
     generativeToken(id: $id) {
@@ -250,7 +250,7 @@ export const Qu_genTokOwners = gql`
 export const Qu_genTokOffers = gql`
   ${Frag_MediaImage}
   ${Frag_UserBadge}
-  query GetGenTokOffers($id: TokenId) {
+  query GetGenTokOffers($id: Float) {
     generativeToken(id: $id) {
       id
       offers(filters: { active_eq: true }) {

--- a/src/queries/marketplace.ts
+++ b/src/queries/marketplace.ts
@@ -9,7 +9,7 @@ export const Qu_genTokListings = gql`
   ${Frag_MediaImage}
   ${Frag_UserBadge}
   query GenTokActiveListings(
-    $id: TokenId!
+    $id: Float!
     $filters: ObjktFilter
     $sort: ObjktsSortInput
     $skip: Int
@@ -51,7 +51,7 @@ export const Qu_genTokListings = gql`
 export const Qu_genTokActions = gql`
   ${Frag_UserBadge}
   query GenTokActions(
-    $id: TokenId!
+    $id: Float!
     $skip: Int
     $take: Int
     $filters: ActionFilter

--- a/src/services/contract-operations/BurnSupplyV3.ts
+++ b/src/services/contract-operations/BurnSupplyV3.ts
@@ -33,7 +33,7 @@ export class BurnSupplyV3Operation extends ContractOperation<TBurnSupplyV3Operat
 
   async call(): Promise<TransactionWalletOperation> {
     const params = {
-      issuer_id: this.params.token.id - 26000,
+      issuer_id: this.params.token.id,
       amount: this.params.supply,
     }
 

--- a/src/services/contract-operations/BurnTokenV3.ts
+++ b/src/services/contract-operations/BurnTokenV3.ts
@@ -32,7 +32,7 @@ export class BurnTokenV3Operation extends ContractOperation<TBurnTokenV3Operatio
   }
 
   async call(): Promise<TransactionWalletOperation> {
-    const params = this.params.token.id - 26000
+    const params = this.params.token.id
 
     // if the author is a collab contract, we have to call the collab contract
     // proposal EP instead

--- a/src/services/contract-operations/MintV3.ts
+++ b/src/services/contract-operations/MintV3.ts
@@ -31,8 +31,6 @@ export type TMintV3OperationParams = {
   inputBytes: string
 }
 
-// todo remove offset when contract updated
-const OFFSET_V3_ID = 26000
 /**
  * Mint an unique iteration of a Generative Token
  */
@@ -108,7 +106,7 @@ export class MintV3Operation extends ContractOperation<TMintV3OperationParams> {
         entrypoint: "mint",
         value: buildParameters(
           {
-            issuer_id: this.params.token.id - OFFSET_V3_ID,
+            issuer_id: this.params.token.id,
             referrer: null,
             reserve_input: this.reserveInput,
             create_ticket: this.params.createTicket ? "" : null,

--- a/src/services/contract-operations/MintWithTicketV3.ts
+++ b/src/services/contract-operations/MintWithTicketV3.ts
@@ -26,7 +26,7 @@ export class MintWithTicketOperation extends ContractOperation<TMintWithTicketOp
 
   async call(): Promise<TransactionWalletOperation> {
     return this.contract!.methodsObject.mint_with_ticket({
-      issuer_id: this.params.token.id - 26000,
+      issuer_id: this.params.token.id,
       ticket_id: this.params.ticketId,
       input_bytes: this.params.inputBytes,
       recipient: null,

--- a/src/services/contract-operations/UpdateIssuerV3.ts
+++ b/src/services/contract-operations/UpdateIssuerV3.ts
@@ -41,7 +41,7 @@ export class UpdateIssuerV3Operation extends ContractOperation<TUpdateIssuerV3Op
     const numbered = transformUpdateIssuerFormToNumbers(this.params.data)
 
     const params = {
-      issuer_id: this.params.token.id - 26000,
+      issuer_id: this.params.token.id,
       enabled: numbered.enabled,
       royalties: numbered.royalties,
       primary_split: numbered.splitsPrimary,

--- a/src/services/contract-operations/UpdatePricingV3.ts
+++ b/src/services/contract-operations/UpdatePricingV3.ts
@@ -45,7 +45,7 @@ export class UpdatePricingV3Operation extends ContractOperation<TUpdatePricingV3
     const packedPricing = packPricing(numbered)
 
     const params = {
-      issuer_id: this.params.token.id - 26000,
+      issuer_id: this.params.token.id,
       pricing: packedPricing,
     }
     console.log(params)

--- a/src/services/contract-operations/UpdateReserveV3.ts
+++ b/src/services/contract-operations/UpdateReserveV3.ts
@@ -43,7 +43,7 @@ export class UpdateReservesV3Operation extends ContractOperation<TUpdateReserves
     }))
 
     const params = {
-      issuer_id: this.params.token.id - 26000,
+      issuer_id: this.params.token.id,
       reserves: reserves,
     }
 


### PR DESCRIPTION
removes the workarounds of TokenId scalars and id offsets now that V3 generative token ids will follow on from the existing sequence