### PR TITLE
add maxCollaborators prop for collabbadge truncation

### DIFF
--- a/src/components/User/CollabBadge.module.scss
+++ b/src/components/User/CollabBadge.module.scss
@@ -25,6 +25,9 @@
 
       &:not(:first-child) {
         margin-left: -28px;
+        &.toggleButton {
+          margin-left: 0px;
+        }
       }
 
       .user_name {
@@ -165,6 +168,9 @@
       .avatar_wrapper {
         &:not(:first-child) {
           margin-left: -20px;
+          &.toggleButton {
+            margin-left: 0px;
+          }
         }
       }
 
@@ -195,6 +201,9 @@
       .avatar_wrapper {
         &:not(:first-child) {
           margin-left: -10px;
+          &.toggleButton {
+            margin-left: 0px;
+          }
         }
       }
 


### PR DESCRIPTION
- fix #546 

This PR adds `maxCollaborators: number` prop to collabbadge. its defaulting to 5. i added some ref magic to ensure the toggle button will overflow the +xxx circle independent of its size.

closing #548 in favor of this pr