### PR TITLE
Fix no menu on breakpoint md

### DIFF
--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,8 +1,8 @@
 import { useMemo } from "react"
 import useWindowSize, { breakpoints } from "./useWindowsSize"
 
-export default function useIsMobile(breakpoint: number = breakpoints.sm) {
+export default function useIsMobile(breakpoint: number = breakpoints.md) {
   const { width } = useWindowSize()
 
-  return useMemo(() => width !== undefined && width <= breakpoint, [width])
+  return useMemo(() => width !== undefined && width <= breakpoint, [width, breakpoint])
 }

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -4,5 +4,8 @@ import useWindowSize, { breakpoints } from "./useWindowsSize"
 export default function useIsMobile(breakpoint: number = breakpoints.md) {
   const { width } = useWindowSize()
 
-  return useMemo(() => width !== undefined && width <= breakpoint, [width, breakpoint])
+  return useMemo(
+    () => width !== undefined && width <= breakpoint,
+    [width, breakpoint]
+  )
 }


### PR DESCRIPTION
There is no menu rendered on breakpoint md because the `useIsMobile` hook had sm breakpoint as default value. I've changed the default mobile breakpoint to md.