### PR TITLE
Feat/gentk contract from api

### DIFF
--- a/src/containers/Token/Edit/Shared/EditGeneralSettings.tsx
+++ b/src/containers/Token/Edit/Shared/EditGeneralSettings.tsx
@@ -3,10 +3,7 @@ import editStyle from "./EditStyle.module.scss"
 import layout from "styles/Layout.module.scss"
 import cs from "classnames"
 import * as Yup from "yup"
-import {
-  GenerativeToken,
-  GenerativeTokenVersion,
-} from "types/entities/GenerativeToken"
+import { GenerativeToken } from "types/entities/GenerativeToken"
 import { Formik } from "formik"
 import { Form } from "components/Form/Form"
 import { Fieldset } from "components/Form/Fieldset"
@@ -16,7 +13,6 @@ import { Spacing } from "components/Layout/Spacing"
 import { InputTextUnit } from "components/Input/InputTextUnit"
 import { InputSplits } from "components/Input/InputSplits"
 import { transformSplitsSum1000 } from "utils/transformers/splits"
-import { FxhashContracts } from "types/Contracts"
 import { Button } from "components/Button"
 import { useContractOperation } from "hooks/useContractOperation"
 import { UpdateIssuerForm } from "types/UpdateIssuer"
@@ -48,11 +44,6 @@ export function EditGeneralSettings({ token, contractOperation }: Props) {
   }
 
   const disabled = token.balance === 0
-
-  const gentkContract =
-    token.version === GenerativeTokenVersion.V3
-      ? FxhashContracts.GENTK_V3
-      : FxhashContracts.GENTK_V2
 
   return (
     <Formik
@@ -177,7 +168,7 @@ export function EditGeneralSettings({ token, contractOperation }: Props) {
                 {({ addAddress }) => (
                   <div className={cs(editStyle.royalties_last_row)}>
                     {!values.splitsSecondary.find(
-                      (split) => split.address === gentkContract
+                      (split) => split.address === token.gentkContractAddress
                     ) && (
                       <Button
                         type="button"
@@ -186,7 +177,7 @@ export function EditGeneralSettings({ token, contractOperation }: Props) {
                           <i className="fa-solid fa-plus" aria-hidden />
                         }
                         onClick={() => {
-                          addAddress(gentkContract)
+                          addAddress(token.gentkContractAddress)
                         }}
                       >
                         royalties to the minter

--- a/src/queries/fragments/generative-token.ts
+++ b/src/queries/fragments/generative-token.ts
@@ -104,6 +104,7 @@ export const Frag_GenTokenInfo = gql`
     ...TokenBadge
     id
     version
+    gentkContractAddress
     inputBytesSize
     slug
     flag

--- a/src/types/entities/GenerativeToken.ts
+++ b/src/types/entities/GenerativeToken.ts
@@ -145,6 +145,7 @@ export interface GenerativeToken {
   mintTickets: MintTicket[]
   mintTicketSettings: MintTicketSettings | null
   inputBytesSize: number
+  gentkContractAddress: string
 }
 
 export interface GenerativeTokenWithCollection extends GenerativeToken {


### PR DESCRIPTION
to avoid incorrect addresses being set in an issuer's royalties, we should defer to the API to inform us which gentk contract address is associated with a particular generative token