### PR TITLE
Fix/accept offer gentk view

### DIFF
--- a/src/queries/objkt.ts
+++ b/src/queries/objkt.ts
@@ -2,10 +2,12 @@ import { gql } from "@apollo/client"
 import { Frag_GenAuthor } from "./fragments/generative-token"
 import { Frag_MediaImage } from "./fragments/media"
 import { Frag_UserBadge } from "./fragments/user"
+import { Frag_GenTokOffer } from "./fragments/offer"
 export const Qu_objkt = gql`
   ${Frag_GenAuthor}
   ${Frag_MediaImage}
   ${Frag_UserBadge}
+  ${Frag_GenTokOffer}
   query Gentk($id: ObjktId, $slug: String) {
     objkt(id: $id, slug: $slug) {
       id
@@ -66,16 +68,7 @@ export const Qu_objkt = gql`
         }
       }
       offers(filters: { active_eq: true }) {
-        id
-        price
-        version
-        createdAt
-        cancelledAt
-        acceptedAt
-        buyer {
-          id
-          name
-        }
+        ...GenTokOffer
       }
       actions {
         id


### PR DESCRIPTION
due to the missing offer.objkt relation in the main objkt query, offers weren't passing the typeguard in the shared accept offer code so the accept button wasn't being shown on offers for the individual gentk view. this fixes it and I believe won't fetch unnecessary data as the dataloader should cache results for the objkt itself in the api