### PR TITLE
Docs/fxparams update modes and fx on

### DIFF
--- a/src/doc/artist/params.md
+++ b/src/doc/artist/params.md
@@ -40,7 +40,7 @@ $fx.getParam("number_id")
 
 # fx(params) update modes
 
-For each individual parameter that you specify, you can also set a specific update mode for. The default update mode is `"page-reload"` and describes the known behaviour of updating the artwork by performing a full page-load on the artwork. By setting the update mode to `"sync"` the parameter will be updated through the controllers without performaing a full page-load on the artwork.
+For each individual parameter that you specify, you can also set a specific update mode for. The default update mode is `"page-reload"` and describes the known behaviour of updating the artwork by performing a full page-load on the artwork. By setting the update mode to `"sync"` the parameter will be updated through the controllers without performing a full page-load on the artwork.
 
 ```js
 {

--- a/src/doc/artist/params.md
+++ b/src/doc/artist/params.md
@@ -38,6 +38,23 @@ $fx.params([
 $fx.getParam("number_id")
 ```
 
+# fx(params) update modes
+
+For each individual parameter that you specify, you can also set a specific update mode for. The default update mode is `"page-reload"` and describes the known behaviour of updating the artwork by performing a full page-load on the artwork. By setting the update mode to `"sync"` the parameter will be updated through the controllers without performaing a full page-load on the artwork.
+
+```js
+{
+  id: "number_id",
+  name: "A number/float64",
+  type: "number",
+  update: "sync", // <-- new update property
+},
+```
+
+All updates on prameters with `update: "sync"` are received in the background in real-time. If your artwork is already running in some kind of draw loop (e.g. via `requestAnimationFrame`), you will receive those changes during the runtime of your loop.
+
+For more even more advanced usecases, e.g. if you want to only re-render you artwork when the values of your parameters are changing, you can use the new event listeners described in the section [`$fx.on`](/doc/artist/snippet-api#fxoneventid-handler-ondone) on the snippet api page. 
+
 # Dev environment for fx(params)
 
 For projects to work with fx(params), two components are needed:

--- a/src/doc/artist/params.md
+++ b/src/doc/artist/params.md
@@ -53,7 +53,7 @@ For each individual parameter that you specify, you can also set a specific upda
 
 All updates on prameters with `update: "sync"` are received in the background in real-time. If your artwork is already running in some kind of draw loop (e.g. via `requestAnimationFrame`), you will receive those changes during the runtime of your loop.
 
-For more even more advanced usecases, e.g. if you want to only re-render you artwork when the values of your parameters are changing, you can use the new event listeners described in the section [`$fx.on`](/doc/artist/snippet-api#fxoneventid-handler-ondone) on the snippet api page. 
+For even more advanced use cases, e.g. if you want to only re-render your artwork when the values of your parameters are changing, you can use the new event listeners described in the section [`$fx.on`](/doc/artist/snippet-api#fxoneventid-handler-ondone) on the snippet api page. 
 
 # Dev environment for fx(params)
 

--- a/src/doc/artist/params.md
+++ b/src/doc/artist/params.md
@@ -40,7 +40,7 @@ $fx.getParam("number_id")
 
 # fx(params) update modes
 
-For each individual parameter that you specify, you can also set a specific update mode for. The default update mode is `"page-reload"` and describes the known behaviour of updating the artwork by performing a full page-load on the artwork. By setting the update mode to `"sync"` the parameter will be updated through the controllers without performing a full page-load on the artwork.
+For each individual parameter that you specify, you can also set a specific update mode for it. The default update mode is `"page-reload"` and describes the known behaviour of updating the artwork by performing a full page-load on the artwork. By setting the update mode to `"sync"` the parameter will be updated through the controllers without performing a full page-load on the artwork.
 
 ```js
 {

--- a/src/doc/artist/snippet-api.md
+++ b/src/doc/artist/snippet-api.md
@@ -585,7 +585,7 @@ A default value for the parameter. If defined, when the minting interface with t
 
 _Optional_
 
-Specifies the update mode of the parameter. The default update mode is `"page-reload"`. With update mode `"page-reload"`, a full page reload on the artwork is performed whenever the value of the parameter changes. When the update mode is set to `"sync"` the values of the parameter are updated during the runtime of the artwork. With update mode `"sync"`, no page reload is performed when the the values of the parameter changed.
+Specifies the update mode of the parameter. The default update mode is `"page-reload"`. With update mode `"page-reload"`, a full page reload on the artwork is performed whenever the value of the parameter changes. When the update mode is set to `"sync"` the parameter values are updated during the runtime of the artwork - no page reload is performed when the parameter values change.
 
 ---
 `options`

--- a/src/doc/artist/snippet-api.md
+++ b/src/doc/artist/snippet-api.md
@@ -42,7 +42,7 @@ $fx.preview()
 | [`getParam()`](#fxgetparamid)       | (string)&nbsp;=>&nbsp;any    | Given a param ID, returns its current value based on the param values passed to the iteration.                                                                                                   |
 | [`getParams()`](#fxgetparams)       | ()&nbsp;=>&nbsp;object       | Return an map of param key value pairs, based on the provided params definition and the current values of all the parameters.                                                                    |
 | [`getRawParam()`](#fxgetrawparamid) | (string)&nbsp;=>&nbsp;string | Returns the bytes string of a parameter as passed to the iteration.                                                                                                                              |
-| [`on()`](#fxoneventid-handler-ondone) | (string, function, function)&nbsp;=>&nbsp;function | Adds an event listener to an event                                                                                                                             |
+| [`on()`](#fxoneventid-handler-ondone) | (string, function, function)&nbsp;=>&nbsp;function | Adds an event listener to an event. returns a function to remove the event listener.                                                                                                                             |
 
 # Top-level API reference
 
@@ -430,13 +430,12 @@ console.log($fx.getParam("another_param"))
 
 > Allows you to subscribe to specific events in the pipeline. Those event subscriptions can be used to trigger effects and override default behaviours
 
-The `eventId` must match an existing `eventId` that you can subscribe to. The `handler` is the function that is called when the event is triggered. Additionally you can return `true` from the `handler` to indicate that the handler has handled the event and no default behaviour should be applied. The `onDone` function is called as the last thing of any event, e.g. after the default behaviour of the event was applied.
+The `eventId` must match an existing `eventId` that you can subscribe to. The `handler` is the function that is called when the event is triggered. Additionally you can opt-out of the default behaviour of an event handler by returning `false` from the handler. The `onDone` function is called as the last thing of any event, e.g. after the default behaviour of the event was applied.
 
 Existing `eventId`'s are:
 - `params:update` is triggered whenever values of params are updated
 
 ```ts
-
 // define your parameters
 $fx.params([
   {
@@ -454,9 +453,9 @@ $fx.on(
   "params:update", // subscribe to the params update event
   (newValues) => {
     // opt-out param update when number_id is 5
-    if  (newValues.number_id === 5) return true;
+    if  (newValues.number_id === 5) return false;
     // opt-in any other param value update
-    return false;
+    return true;
   },
   () => main(), // render artwork when event was handled
 )
@@ -468,11 +467,22 @@ Following is the typescript definition of the `$fx.on` function:
 type FxOnFunction = (
   eventId: string
   handler: (...args) => boolean | Promise<boolean>
-  onDone: () => void
+  onDone: (optInDefault: boolean, ...args) => void
 ) => () => void
 ```
 
-The function returned by the `$fx.on` function can be called to remove the registerd event listener.
+The function returned by the `$fx.on` function can be called to remove the registered event listener.
+
+```ts
+const removeListener = $fx.on(
+  "params:update",
+  (newValues) => {
+    // do something
+  },
+)
+
+removeListener() // <-- Will remove the event listener
+```
 
 # fx(params)
 


### PR DESCRIPTION
This PR adds a first version of the documentation for fx(params) update modes and `$fx.on`

- https://fxhash-git-docs-fxparams-update-modes-and-fx-on-fxhash.vercel.app/doc/artist/params#fxparams-update-modes
- https://fxhash-git-docs-fxparams-update-modes-and-fx-on-fxhash.vercel.app/doc/artist/snippet-api#fxoneventid-handler-ondone