### PR TITLE
disable using access list reserves with winter

### DIFF
--- a/src/components/CreditCard/CreditCardCheckout.tsx
+++ b/src/components/CreditCard/CreditCardCheckout.tsx
@@ -1,13 +1,9 @@
-import {
-  ComponentProps,
-  forwardRef,
-  useImperativeHandle,
-  useState,
-} from "react"
+import { forwardRef, useImperativeHandle, useState } from "react"
 import { winterCheckoutAppearance } from "utils/winter"
 import WinterCheckout, { IWinterMintPass } from "./WinterCheckout"
 import { IReserveConsumption } from "services/contract-operations/Mint"
 import { prepareReserveConsumption } from "utils/pack/reserves"
+import { EReserveMethod } from "types/entities/Reserve"
 
 interface MintParams {
   create_ticket: string | null
@@ -65,6 +61,10 @@ export const CreditCardCheckout = forwardRef<
      */
     const prepare = async () => {
       if (!consumeReserve) return
+      if (consumeReserve.method !== EReserveMethod.MINT_PASS)
+        throw new Error(
+          "only mint pass reserve consumption is supported for credit card checkout"
+        )
 
       try {
         const { reserveInput, payloadPacked, payloadSignature } =

--- a/src/components/GenerativeToken/MintButton.tsx
+++ b/src/components/GenerativeToken/MintButton.tsx
@@ -10,6 +10,7 @@ import { ButtonPaymentCard } from "../Utils/ButtonPaymentCard"
 import { useMintReserveInfo } from "hooks/useMintReserveInfo"
 import { LiveMintingContext } from "context/LiveMinting"
 import { ReserveDropdown } from "./ReserveDropdown"
+import { EReserveMethod } from "types/entities/Reserve"
 
 /**
  * The Mint Button displays a mint button component with specific display rules
@@ -105,7 +106,9 @@ export function MintButton({
         {hasCreditCardOption &&
           !freeLiveMinting &&
           !loading &&
-          (!onlyReserveLeft || onMintShouldUseReserve) && (
+          (!onlyReserveLeft || onMintShouldUseReserve) &&
+          // access list reserves not currently supported by winter integration
+          reserveConsumptionMethod?.method === EReserveMethod.MINT_PASS && (
             <ButtonPaymentCard
               onClick={openCreditCard}
               disabled={disabled}


### PR DESCRIPTION
passing `recipient` does not enable other wallets to consume reserves on behalf of the reserve holder, so we still can't facilitate access list reserves thru winter