### PR TITLE
fix winter / access list reserve logic

### DIFF
--- a/src/components/GenerativeToken/MintButton.tsx
+++ b/src/components/GenerativeToken/MintButton.tsx
@@ -106,9 +106,7 @@ export function MintButton({
         {hasCreditCardOption &&
           !freeLiveMinting &&
           !loading &&
-          (!onlyReserveLeft || onMintShouldUseReserve) &&
-          // access list reserves not currently supported by winter integration
-          reserveConsumptionMethod?.method === EReserveMethod.MINT_PASS && (
+          (!onlyReserveLeft || onMintShouldUseReserve) && (
             <ButtonPaymentCard
               onClick={openCreditCard}
               disabled={disabled}

--- a/src/components/GenerativeToken/MintController.tsx
+++ b/src/components/GenerativeToken/MintController.tsx
@@ -43,6 +43,7 @@ import {
   CreditCardCheckoutHandle,
 } from "components/CreditCard/CreditCardCheckout"
 import { checkIsEligibleForMintWithAutoToken } from "utils/generative-token"
+import { EReserveMethod } from "types/entities/Reserve"
 
 interface Props {
   token: GenerativeToken
@@ -398,7 +399,12 @@ export function MintController({
           referrer: null,
           recipient: user?.id,
         }}
-        consumeReserve={reserveConsumptionMethod}
+        consumeReserve={
+          // access list reserves not currently supported by winter integration
+          reserveConsumptionMethod?.method === EReserveMethod.MINT_PASS
+            ? reserveConsumptionMethod
+            : null
+        }
       />
     </div>
   )


### PR DESCRIPTION
we still want to show the winter option when the user has access list reserve - but we don't want to attempt to use the reserve so avoid passing to `CreditCardCheckout` 