### PR TITLE
Fix/winter reserves

### DIFF
--- a/src/components/CreditCard/CreditCardCheckout.tsx
+++ b/src/components/CreditCard/CreditCardCheckout.tsx
@@ -1,13 +1,9 @@
-import {
-  ComponentProps,
-  forwardRef,
-  useImperativeHandle,
-  useState,
-} from "react"
+import { forwardRef, useImperativeHandle, useState } from "react"
 import { winterCheckoutAppearance } from "utils/winter"
 import WinterCheckout, { IWinterMintPass } from "./WinterCheckout"
 import { IReserveConsumption } from "services/contract-operations/Mint"
 import { prepareReserveConsumption } from "utils/pack/reserves"
+import { EReserveMethod } from "types/entities/Reserve"
 
 interface MintParams {
   create_ticket: string | null
@@ -65,6 +61,10 @@ export const CreditCardCheckout = forwardRef<
      */
     const prepare = async () => {
       if (!consumeReserve) return
+      if (consumeReserve.method !== EReserveMethod.MINT_PASS)
+        throw new Error(
+          "only mint pass reserve consumption is supported for credit card checkout"
+        )
 
       try {
         const { reserveInput, payloadPacked, payloadSignature } =

--- a/src/components/GenerativeToken/MintButton.tsx
+++ b/src/components/GenerativeToken/MintButton.tsx
@@ -10,6 +10,7 @@ import { ButtonPaymentCard } from "../Utils/ButtonPaymentCard"
 import { useMintReserveInfo } from "hooks/useMintReserveInfo"
 import { LiveMintingContext } from "context/LiveMinting"
 import { ReserveDropdown } from "./ReserveDropdown"
+import { EReserveMethod } from "types/entities/Reserve"
 
 /**
  * The Mint Button displays a mint button component with specific display rules
@@ -105,7 +106,11 @@ export function MintButton({
         {hasCreditCardOption &&
           !freeLiveMinting &&
           !loading &&
-          (!onlyReserveLeft || onMintShouldUseReserve) && (
+          (!onlyReserveLeft ||
+            (onMintShouldUseReserve &&
+              // access list reserves not currently supported by winter integration
+              reserveConsumptionMethod?.method ===
+                EReserveMethod.MINT_PASS)) && (
             <ButtonPaymentCard
               onClick={openCreditCard}
               disabled={disabled}

--- a/src/containers/Generative/Display/GenerativeDisplayIteration.tsx
+++ b/src/containers/Generative/Display/GenerativeDisplayIteration.tsx
@@ -128,7 +128,11 @@ const _GenerativeDisplayIteration = ({
 
           <div className={cs(style.buttons, style.actions)}>
             {objkt.activeListing && (
-              <ListingAccept listing={objkt.activeListing} objkt={objkt} />
+              <ListingAccept
+                listing={objkt.activeListing}
+                objkt={objkt}
+                showCreditCardOption={objkt.activeListing.version !== 0}
+              />
             )}
             {/* @ts-ignore */}
             <ClientOnlyEmpty style={{ width: "100%" }}>

--- a/src/containers/Objkt/ListingAccept.tsx
+++ b/src/containers/Objkt/ListingAccept.tsx
@@ -23,9 +23,13 @@ import { getUserProfileLink } from "../../utils/user"
 interface Props {
   listing: Listing
   objkt: Objkt
+  showCreditCardOption?: boolean
 }
-
-export function ListingAccept({ listing, objkt }: Props) {
+export function ListingAccept({
+  listing,
+  objkt,
+  showCreditCardOption = true,
+}: Props) {
   const [showWinterCheckout, setShowWinterCheckout] = useState(false)
   const [showWinterPaymentOptions, setShowWinterPaymentOptions] =
     useState(false)
@@ -128,15 +132,17 @@ export function ListingAccept({ listing, objkt }: Props) {
                 formatBig={false}
               />
             </Button>
-            {!contractLoading && !showWinterCheckout && (
-              <ButtonPaymentCard
-                onClick={handleToggleWinterPaymentOptions(
-                  !showWinterPaymentOptions
-                )}
-                disabled={locked}
-                hasDropdown={showWinterPaymentOptions ? "up" : "down"}
-              />
-            )}
+            {showCreditCardOption &&
+              !contractLoading &&
+              !showWinterCheckout && (
+                <ButtonPaymentCard
+                  onClick={handleToggleWinterPaymentOptions(
+                    !showWinterPaymentOptions
+                  )}
+                  disabled={locked}
+                  hasDropdown={showWinterPaymentOptions ? "up" : "down"}
+                />
+              )}
             {locked && (
               <Unlock locked={true} onClick={() => setLocked(false)} />
             )}


### PR DESCRIPTION
adds back reverted functionality (actually working this time round) to:
- hide the credit card button for v0 listings (winter never implemented support for these)
- only show the credit card button for mint pass reserves, not for access list reserves (no support for AL either)