### PR TITLE
Fix/old snippet params variations

### DIFF
--- a/src/components/GenerativeToken/GenerativeArtwork.tsx
+++ b/src/components/GenerativeToken/GenerativeArtwork.tsx
@@ -14,8 +14,8 @@ import { SettingsContext } from "../../context/Theme"
 import { ipfsGatewayUrl } from "../../services/Ipfs"
 import { Image } from "../Image"
 import { useReceiveTokenInfos } from "hooks/useReceiveTokenInfos"
-import { getGenerativeTokenUrl } from "utils/generative-token"
 import { ButtonExploreParams } from "components/Button/ButtonExploreParams"
+
 interface Props {
   token: Pick<
     GenerativeToken,
@@ -50,6 +50,7 @@ export function GenerativeArtwork({
   const artworkIframeRef = useRef<ArtworkIframeRef>(null)
 
   const { params, onIframeLoaded } = useReceiveTokenInfos(artworkIframeRef)
+  const paramsDefinition = params || token.metadata.params.definition
 
   const previewVariant = useMemo<Variant>(
     () => [
@@ -152,7 +153,7 @@ export function GenerativeArtwork({
           <ButtonVariations
             token={token}
             variant={variant}
-            params={params}
+            params={paramsDefinition}
             onChangeVariant={(v) => {
               setDisplayImage(false)
               setVariant(v)

--- a/src/components/GenerativeToken/GenerativeArtwork.tsx
+++ b/src/components/GenerativeToken/GenerativeArtwork.tsx
@@ -49,8 +49,10 @@ export function GenerativeArtwork({
   const settings = useContext(SettingsContext)
   const artworkIframeRef = useRef<ArtworkIframeRef>(null)
 
-  const { params, onIframeLoaded } = useReceiveTokenInfos(artworkIframeRef)
-  const paramsDefinition = params || token.metadata.params.definition
+  const { paramsDefinition: paramsDefinitionFromIframe, onIframeLoaded } =
+    useReceiveTokenInfos(artworkIframeRef)
+  const paramsDefinition =
+    paramsDefinitionFromIframe || token.metadata.params.definition
 
   const previewVariant = useMemo<Variant>(
     () => [

--- a/src/components/GenerativeToken/GenerativeArtwork.tsx
+++ b/src/components/GenerativeToken/GenerativeArtwork.tsx
@@ -52,7 +52,7 @@ export function GenerativeArtwork({
   const { paramsDefinition: paramsDefinitionFromIframe, onIframeLoaded } =
     useReceiveTokenInfos(artworkIframeRef)
   const paramsDefinition =
-    paramsDefinitionFromIframe || token.metadata.params.definition
+    paramsDefinitionFromIframe || token.metadata.params?.definition
 
   const previewVariant = useMemo<Variant>(
     () => [

--- a/src/hooks/useReceiveTokenInfos.ts
+++ b/src/hooks/useReceiveTokenInfos.ts
@@ -75,7 +75,7 @@ function handleOldSnippetEvents(
 }
 
 export function useReceiveTokenInfos(
-  ref: React.RefObject<ArtworkIframeRef | null>,
+  ref: React.RefObject<ArtworkIframeRef | null>
 ): IFrameTokenInfos {
   const runtime = useRuntime()
   const { state, definition } = runtime

--- a/src/hooks/useRuntime.ts
+++ b/src/hooks/useRuntime.ts
@@ -137,7 +137,7 @@ export function useRuntime(initial?: Parameters): IRuntimeContext {
       params:
         definition.params?.map((p: FxParamDefinition<FxParamType>) => ({
           ...p,
-          version: definition.version || "0",
+          ...(definition.version && { version: definition.version }),
         })) || null,
     }),
     [definition]

--- a/src/hooks/useRuntimeController.ts
+++ b/src/hooks/useRuntimeController.ts
@@ -152,7 +152,7 @@ const iframeHandler: TRuntimeContextConnector = (iframeRef) => {
           fxminter: state.minter || "",
           fxparams: state.inputBytes,
           fxcontext: state.context,
-        }) + `&${searchParams}`
+        }) + (searchParams ? `?${searchParams}` : "")
       )
     },
     useSync(runtimeUrl: string, controlsUrl: string) {


### PR DESCRIPTION
- for e.g. https://www.fxhash.xyz/generative/26248, the variations are broken as we are not correctly passing the params definition to be serialized, so it's opening with random params and changing on each refresh. this PR should fix that issue

- also fixes an issue with the old snippet where params weren't serializing correctly as we were passing a default version so the incorrect serialization code was being used