### PR TITLE
temporarily filter inactive redeemables

### DIFF
--- a/src/containers/Generative/Redeem/GenerativeRedeem.tsx
+++ b/src/containers/Generative/Redeem/GenerativeRedeem.tsx
@@ -45,7 +45,17 @@ const _GenerativeRedeem = ({
     nextFetchPolicy: "cache-and-network",
   })
 
-  const tokens: Objkt[] | null = data?.generativeToken?.objkts
+  /**
+   * TEMP UNTIL WE HAVE AN API FIX
+   * filter out any redeemables that have been made inactive
+   */
+  const activeRedeemableAddresses = redeemableDetails.map((r) => r.address)
+  const tokens: Objkt[] | null = data?.generativeToken?.objkts.filter(
+    (o: Objkt) =>
+      o.availableRedeemables.some((r) =>
+        activeRedeemableAddresses.includes(r.address)
+      )
+  )
 
   const { topMarkerRef, onEndReached } = useInfiniteScroll({
     loading,

--- a/src/pages/generative/[id]/redeem.tsx
+++ b/src/pages/generative/[id]/redeem.tsx
@@ -82,6 +82,10 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
               address: {
                 in: token.redeemables.map((red: any) => red.address),
               },
+              // only get active redeemables
+              active: {
+                equals: true,
+              },
             },
           },
         })

--- a/src/pages/gentk/[id]/redeem/index.tsx
+++ b/src/pages/gentk/[id]/redeem/index.tsx
@@ -129,6 +129,10 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
               address: {
                 in: objkt.availableRedeemables.map((red: any) => red.address),
               },
+              // only get active redeemables
+              active: {
+                equals: true,
+              },
             },
           },
         })


### PR DESCRIPTION
we can't delete redeemables in the backend rn so to avoid having multiple broken redeemables displayed in the frontend, this pr filters out all redeemables that have been made inactive from the UI. once we implement proper deletion of redeemables these manual fixes can be removed