### PR TITLE
Enhancement/context selection as buttons below artwork

### DIFF
--- a/src/components/Testing/ContextTest.module.scss
+++ b/src/components/Testing/ContextTest.module.scss
@@ -2,6 +2,15 @@
   small {
     font-weight: bold;
   }
+  .buttons {
+    margin-top: var(--spacing);
+    display: flex;
+    justify-content: space-between;
+    gap: var(--spacing);
+  }
+  .button {
+    flex-grow: 1;
+  }
   .select {
     width: 100%;
   }

--- a/src/components/Testing/ContextTest.tsx
+++ b/src/components/Testing/ContextTest.tsx
@@ -1,16 +1,18 @@
 import styles from "./ContextTest.module.scss"
 import { TExecutionContext } from "hooks/useRuntime"
 import { Select } from "components/Input/Select"
+import { Button } from "components/Button"
 
 interface Props {
   value: TExecutionContext | null | undefined
   onChange: (value: TExecutionContext) => void
+  asButtons?: boolean
 }
 
-const contexts = ["minting", "standalone", "capture"]
+const contexts: TExecutionContext[] = ["minting", "standalone", "capture"]
 
 export function ContextTest(props: Props) {
-  const { onChange, value } = props
+  const { onChange, value, asButtons = false } = props
 
   const handleChange = (context: TExecutionContext) => {
     onChange(context)
@@ -19,15 +21,31 @@ export function ContextTest(props: Props) {
   return (
     <div className={styles.contexttest}>
       <small>Context</small>
-      <Select
-        className={styles.select}
-        value={value}
-        onChange={handleChange}
-        options={contexts.map((c) => ({
-          value: c,
-          label: c,
-        }))}
-      />
+      {asButtons ? (
+        <div className={styles.buttons}>
+          {contexts.map((context) => (
+            <Button
+              className={styles.button}
+              size="small"
+              key={context}
+              onClick={() => handleChange(context)}
+              color={value === context ? "primary" : "black"}
+            >
+              {context}
+            </Button>
+          ))}
+        </div>
+      ) : (
+        <Select
+          className={styles.select}
+          value={value}
+          onChange={handleChange}
+          options={contexts.map((c) => ({
+            value: c,
+            label: c,
+          }))}
+        />
+      )}
     </div>
   )
 }

--- a/src/containers/MintGenerative/StepCheckFiles.tsx
+++ b/src/containers/MintGenerative/StepCheckFiles.tsx
@@ -105,7 +105,10 @@ export const StepCheckFiles: StepComponent = ({ onNext, state }) => {
           </ul>
 
           <Spacing size="3x-large" sm="x-large" />
-          <div className={layout.show_sm}>{artwork}</div>
+          <div className={layout.show_sm}>
+            {artwork}
+            <Spacing size="3x-large" sm="x-large" />
+          </div>
 
           <HashTest
             autoGenerate={false}

--- a/src/containers/MintGenerative/StepCheckFiles.tsx
+++ b/src/containers/MintGenerative/StepCheckFiles.tsx
@@ -7,7 +7,7 @@ import {
   ArtworkIframe,
   ArtworkIframeRef,
 } from "../../components/Artwork/PreviewIframe"
-import { useState, useRef } from "react"
+import { useState, useRef, useMemo } from "react"
 import { HashTest } from "../../components/Testing/HashTest"
 import { Checkbox } from "../../components/Input/Checkbox"
 import { Button } from "../../components/Button"
@@ -45,6 +45,32 @@ export const StepCheckFiles: StepComponent = ({ onNext, state }) => {
     })
   }
 
+  const artwork = useMemo(
+    () => (
+      <div className={cs(style.artwork)}>
+        <div className={cs(style["preview-cont"])}>
+          <div className={cs(style["preview-wrapper"])}>
+            <ArtworkFrame>
+              <ArtworkIframe
+                ref={artworkIframeRef}
+                url={details.activeUrl}
+                textWaiting="looking for content on IPFS"
+              />
+            </ArtworkFrame>
+          </div>
+        </div>
+        <Spacing size="regular" />
+        <ContextTest
+          asButtons
+          value={runtime.state.context}
+          onChange={(context) => {
+            runtime.state.update({ context })
+          }}
+        />
+      </div>
+    ),
+    [details.activeUrl, runtime.state]
+  )
   return (
     <>
       <p>
@@ -79,6 +105,7 @@ export const StepCheckFiles: StepComponent = ({ onNext, state }) => {
           </ul>
 
           <Spacing size="3x-large" sm="x-large" />
+          <div className={layout.show_sm}>{artwork}</div>
 
           <HashTest
             autoGenerate={false}
@@ -107,13 +134,6 @@ export const StepCheckFiles: StepComponent = ({ onNext, state }) => {
               artworkIframeRef.current?.reloadIframe()
             }}
           />
-          <Spacing size="x-large" sm="x-large" />
-          <ContextTest
-            value={runtime.state.context}
-            onChange={(context) => {
-              runtime.state.update({ context })
-            }}
-          />
           <Spacing size="2x-large" sm="x-large" />
           {controls.state.params.definition && (
             <div>
@@ -136,21 +156,7 @@ export const StepCheckFiles: StepComponent = ({ onNext, state }) => {
           </div>
         </div>
         <div className={layout.hide_sm}>
-          <div className={cs(style.artworkWrapper)}>
-            <div className={cs(style.artwork)}>
-              <div className={cs(style["preview-cont"])}>
-                <div className={cs(style["preview-wrapper"])}>
-                  <ArtworkFrame>
-                    <ArtworkIframe
-                      ref={artworkIframeRef}
-                      url={details.activeUrl}
-                      textWaiting="looking for content on IPFS"
-                    />
-                  </ArtworkFrame>
-                </div>
-              </div>
-            </div>
-          </div>
+          <div className={cs(style.artworkWrapper)}>{artwork}</div>
         </div>
       </div>
 


### PR DESCRIPTION
The context selection was moved below the artwork as buttons. This should solve some confusion for artists that were under the impression that the context selection would somehow be related to the settings of the preview. 

<img width="1624" alt="Screenshot 2023-07-05 at 19 40 29" src="https://github.com/fxhash/fxhash-website/assets/1128485/11454555-3366-4f1a-86b4-51edc84d4ec8">

# How to test

- Open the preview (see comment below from vercel bot)
- Navigate to the "Mint generative Token" flow
- Upload an artwork
=> The context buttons show now be displayed below the artwork

Project to upload: [project.zip](https://github.com/fxhash/fxhash-website/files/11965999/project.zip)

# Implementation details

- I added an `asButtons` property to the `ContextTest` component that renders the context selection as buttons instead of a select menu
- I fixed an issue that we were actually not rendering the artwork on small breakpoints anymore 🤣 