### PR TITLE
Enhacement/event section redesign

### DIFF
--- a/src/components/Card/CardEvent.module.scss
+++ b/src/components/Card/CardEvent.module.scss
@@ -9,7 +9,6 @@
   background: var(--color-gray-vvvvlight);
   color: var(--color-black);
   text-decoration: none !important;
-  height: 350px;
   .cardHeader {
     aspect-ratio: 293 / 286;
     height: 150px;
@@ -29,6 +28,7 @@
   font-size: 16px;
   font-weight: 700;
   line-height: 20px;
+  margin-bottom: var(--spacing-xl);
 }
 .date, .location {
   font-size: 14px;

--- a/src/components/Card/CardEvent.module.scss
+++ b/src/components/Card/CardEvent.module.scss
@@ -1,160 +1,45 @@
 @import "../../styles/Variables";
 
 .card {
-  border: 3px solid var(--color-border);
   width: 100%;
-  aspect-ratio: 293 / 286;
-  border-radius: 4px;
-  padding: 12px 20px;
   position: relative;
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  color: white;
-  background-size: cover;
-  background-position: center center;
-  .card_body {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0 16px;
+  background: var(--color-gray-vvvvlight);
+  color: var(--color-black);
+  text-decoration: none !important;
+  height: 350px;
+  .cardHeader {
+    aspect-ratio: 293 / 286;
+    height: 150px;
+    width: 100%;
+    background-size: cover;
+    background-position: center center;
   }
-  .card_verso {
-    position: absolute;
-    z-index: 2;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
+  .cardBody {
+    padding: var(--spacing);
     display: flex;
     flex-direction: column;
-    background: var(--color-white);
-    color: var(--color-black);
-    transform: translateY(101%);
-    will-change: transform;
-    transition: transform 0.2s $timing-cubic;
-  }
-  &:hover {
-    .card_verso {
-      transform: translateY(0);
-    }
+    justify-content: space-between;
+    flex-grow: 1;
   }
 }
-.card_title {
-  font-size: 24px;
+.title {
+  font-size: 16px;
   font-weight: 700;
+  line-height: 20px;
 }
-.card_date {
-  font-size: 19px;
-  font-weight: 600;
-  line-height: 1.26;
+.date, .location {
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 18px;
 }
-.card_text {
-  opacity: 0.8;
-  font-size: var(--font-size-small);
-}
-.card_artists {
-  flex: 1;
-  background-color: var(--color-gray-vvvlight);
-  padding: 8px 20px;
-  overflow: auto;
-
-  & > div > a {
-    display: block;
-  }
-  & > div + div {
-    margin-top: 8px;
-  }
-}
-.cta_view_event {
-  font-size: 19px;
-  line-height: 1.3;
-  color: var(--color-black);
-  font-weight: 600;
-  padding: 12px 20px;
-}
-.card_header {
-  padding: 12px 20px 8px;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  .card_infos {
-    flex: 1;
-  }
-  .cta_calendar {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: flex-end;
-    width: 40px;
-    height: 40px;
-    font-size: 26px;
-    color: currentColor;
-    border: none;
-    background: none;
-    box-shadow: none;
-    cursor: pointer;
-    padding: 0;
-    transition: 0.2s color ease-out;
-    &:hover {
-      color: var(--color-secondary);
-    }
-  }
-}
-.artists {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  & > span {
-    font-weight: 600;
-    font-size: 20px;
-  }
-  & > i {
-    display: flex;
-    font-size: 32px;
-  }
-}
-.timer {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  font-size: var(--font-size-small);
-  .label {
-    opacity: 0.8;
-  }
-}
-.dot {
-  height: 10px;
-  width: 10px;
-  background-color: var(--color-error);
-  border-radius: 50%;
-  margin-right: 8px;
-  position: relative;
-  &.dot_active {
-    background-color: var(--color-success);
-    &::before {
-      content: "";
-      animation: ping 1s cubic-bezier(0, 0, 0.2, 1) infinite;
-      position: absolute;
-      height: 100%;
-      width: 100%;
-      border-radius: 50%;
-      background-color: var(--color-success);
-    }
-  }
+.location {
+  color: var(--color-gray);
 }
 
 @media (max-width: $breakpoint-sm) {
-  .card, .card_artists, .cta_view_event {
-    padding-left: 16px;
-    padding-right: 16px;
-  }
-  .card_title {
-    font-size: 22px;
-  }
-  .card_date {
-    font-size: 17px;
+  .card {
   }
 }

--- a/src/components/Card/CardEvent.tsx
+++ b/src/components/Card/CardEvent.tsx
@@ -34,20 +34,7 @@ const _CardEvent = ({ event }: CardEventProps) => {
   } = event
   const [now, setNow] = useState(new Date())
   const dateStartAt = useMemo(() => new Date(startsAt), [startsAt])
-  const handleEndTimer = useCallback(() => setNow(new Date()), [])
-  const handleClickCalendar = useCallback(async () => {
-    const icsCreateEvent = (await import("ics")).createEvent
-    icsCreateEvent(generateCalendarDataForEvent(event), (error, value) => {
-      if (error) {
-        console.error(error)
-        return
-      }
-      downloadTextAsGeneratedFile(
-        `${format(dateStartAt, "yyyy-M-d")}-${id}.ics`,
-        value
-      )
-    })
-  }, [dateStartAt, event, id])
+  const dateEndsAt = useMemo(() => new Date(endsAt), [endsAt])
   const eventTimeStatus = useMemo<"upcoming" | "ongoing" | "past">(() => {
     const isLive = now > dateStartAt
     if (!isLive) return "upcoming"
@@ -58,89 +45,28 @@ const _CardEvent = ({ event }: CardEventProps) => {
   const styleBackground = {
     backgroundImage: `linear-gradient(rgba(0, 0, 0, 0.54), rgba(0, 0, 0, 0.54)), url(${imageUrl})`,
   }
-  const availabilitiesStr = useMemo(() => {
-    return availabilities
-      .map((availability) => availabilityLabels[availability])
-      .join(" and ")
-  }, [availabilities])
   return (
-    <div className={style.card} style={styleBackground}>
-      <div>
-        <h4 className={style.card_title}>{name}</h4>
-        <Spacing size="2x-small" />
-        <div className={style.card_text}>{location}</div>
-      </div>
-      <div className={style.card_body}>
-        <div>
-          <div className={style.card_text}>Scheduled</div>
-          <Spacing size="2x-small" />
-          <div className={style.card_date}>
-            {format(dateStartAt, "do MMMM yyyy")} at&nbsp;
-            {format(dateStartAt, "H:mm")}
-          </div>
-          <Spacing size="x-small" />
-          <div className={style.timer}>
-            <span
-              className={cs(style.dot, {
-                [style.dot_active]: eventTimeStatus === "ongoing",
-              })}
-            />
-            {eventTimeStatus === "upcoming" && (
-              <span className={style.label}>
-                <span>Starts in </span>
-                <Countdown until={dateStartAt} onEnd={handleEndTimer} />
-              </span>
-            )}
-            {eventTimeStatus === "ongoing" && (
-              <span className={style.label}>Ongoing</span>
-            )}
-            {eventTimeStatus === "past" && (
-              <span className={style.label}>Finished</span>
-            )}
-          </div>
-        </div>
-        {artists.length > 0 && (
-          <div className={style.artists}>
-            <span>{artists.length}</span>
-            <i aria-hidden="true" aria-label="artists">
-              {iconArtist}
-            </i>
-          </div>
-        )}
-      </div>
-      <div className={style.card_verso}>
-        <div className={style.card_header}>
-          <div className={style.card_infos}>
-            <div className={style.card_title}>Exhibiting</div>
-            {availabilities.length > 0 && (
-              <>
-                <Spacing size="2x-small" />
-                <div className={style.card_text}>
-                  Available {availabilitiesStr}
-                </div>
-              </>
-            )}
-          </div>
-          <button
-            className={style.cta_calendar}
-            onClick={handleClickCalendar}
-            title="Save to your calendar"
-          >
-            <i className="fa-regular fa-calendar-circle-plus" />
-          </button>
-        </div>
-        <div className={style.card_artists}>
-          {artists.map((artist) => (
-            <div key={artist.id}>
-              <EntityBadge user={artist} size="small" hasLink />
+    <Link href={`/events/${id}/onboarding`}>
+      <a className={style.card}>
+        <div className={style.cardHeader} style={styleBackground} />
+        <div className={style.cardBody}>
+          <h4 className={style.title}>{name}</h4>
+          <div>
+            <div className={style.date}>
+              {format(dateStartAt, "do MMMM yyyy")}
+              {eventTimeStatus === "upcoming" && (
+                <> @ {format(dateStartAt, "Haaa")}</>
+              )}
+              {startsAt !== endsAt && eventTimeStatus !== "upcoming" && (
+                <> — {format(dateEndsAt, "do MMM yyyy")}</>
+              )}
             </div>
-          ))}
+            <Spacing size="x-small" />
+            <div className={style.location}>{location || "online"}</div>
+          </div>
         </div>
-        <Link href={`/events/${id}/onboarding`}>
-          <a className={style.cta_view_event}>View event</a>
-        </Link>
-      </div>
-    </div>
+      </a>
+    </Link>
   )
 }
 

--- a/src/components/Card/CardEvent.tsx
+++ b/src/components/Card/CardEvent.tsx
@@ -62,7 +62,7 @@ const _CardEvent = ({ event }: CardEventProps) => {
               )}
             </div>
             <Spacing size="x-small" />
-            <div className={style.location}>{location || "online"}</div>
+            <div className={style.location}>{location || "Online"}</div>
           </div>
         </div>
       </a>

--- a/src/containers/Homepage/HomeDocs.tsx
+++ b/src/containers/Homepage/HomeDocs.tsx
@@ -1,0 +1,76 @@
+import React from "react"
+import style from "./HomeHero.module.scss"
+import Link from "next/link"
+import layout from "../../styles/Layout.module.scss"
+import cs from "classnames"
+import { UserBadge } from "../../components/User/UserBadge"
+import { NFTArticle } from "../../types/entities/Article"
+
+const docs = [
+  {
+    title: "Publishing a project on fxhash",
+    subtitle: "Quick start guide on creating on fxhash",
+    url: "/doc/artist/guide-publish-generative-token",
+  },
+  {
+    title: "Collecting on fxhash",
+    subtitle: "How to get started to collect pieces on fxhash",
+    url: "/doc/collect/guide",
+  },
+  {
+    title: "Integration guide",
+    subtitle: "For developers building on fxhash",
+    url: "/doc/fxhash/integration-guide",
+  },
+]
+
+interface HomeDocsProps {
+  articles: NFTArticle[]
+}
+
+export function HomeDocs(props: HomeDocsProps) {
+  const { articles } = props
+  return (
+    <div className={cs(style.articles_container, layout["padding-big"])}>
+      <div className={style.articles}>
+        <div className={style.docs}>
+          <h6>get started docs</h6>
+          <div>
+            {docs.map((doc) => (
+              <div className={style.doc} key={doc.title}>
+                <Link href={doc.url}>
+                  <a>
+                    <span>{doc.title}</span>
+                  </a>
+                </Link>
+                <div className={style.subtitle}>{doc.subtitle}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className={style.user_articles}>
+          <div>
+            <h6>community articles</h6>
+            <div>
+              {articles.map((article) => (
+                <div className={style.user_article} key={article.id}>
+                  <Link href={`/article/${article.slug}`}>
+                    <a>
+                      <span className={style.title}>{article.title}</span>
+                    </a>
+                  </Link>
+                  <div className={style.subtitle}>
+                    <span className={style.written}>Written by</span>
+                    {article.author && (
+                      <UserBadge user={article.author} displayAvatar={false} />
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/containers/Homepage/HomeEvents.tsx
+++ b/src/containers/Homepage/HomeEvents.tsx
@@ -89,7 +89,7 @@ const _HomeEvents = ({ events }: HomeEventsProps) => {
   const offset = Math.max(0, 4 - eventsWithArtist.length)
   return (
     <div className={cs(layout["padding-big"], style.container)}>
-      <TitleHyphen>upcoming events</TitleHyphen>
+      <TitleHyphen>events</TitleHyphen>
       <Spacing size="2x-large" />
       <div className={style.container_events}>
         {eventsWithArtist.map((event) => (

--- a/src/containers/Homepage/HomeHero.module.scss
+++ b/src/containers/Homepage/HomeHero.module.scss
@@ -48,7 +48,6 @@
   }
 }
 .articles_container {
-  margin-top: 104px;
 }
 .articles {
   border-top: 1px solid var(--color-gray-vlight);

--- a/src/containers/Homepage/HomeHero.tsx
+++ b/src/containers/Homepage/HomeHero.tsx
@@ -1,39 +1,16 @@
 import React, { memo, useMemo, useState } from "react"
 import style from "./HomeHero.module.scss"
 import { GenerativeToken } from "../../types/entities/GenerativeToken"
-import Link from "next/link"
 import { RandomIterativeCycler } from "./RandomIterativeCycler"
 import { ProgressText } from "../../components/ProgressText/ProgressText"
 import colors from "../../styles/Colors.module.css"
-import layout from "../../styles/Layout.module.scss"
 import { ConnectWithUs } from "../../components/ConnectWithUs/ConnectWithUs"
-import cs from "classnames"
-import { NFTArticle } from "../../types/entities/Article"
-import { UserBadge } from "../../components/User/UserBadge"
-
-const docs = [
-  {
-    title: "Publishing a project on fxhash",
-    subtitle: "Quick start guide on creating on fxhash",
-    url: "/doc/artist/guide-publish-generative-token",
-  },
-  {
-    title: "Collecting on fxhash",
-    subtitle: "How to get started to collect pieces on fxhash",
-    url: "/doc/collect/guide",
-  },
-  {
-    title: "Integration guide",
-    subtitle: "For developers building on fxhash",
-    url: "/doc/fxhash/integration-guide",
-  },
-]
 
 interface HomeHeroProps {
   randomGenerativeToken: GenerativeToken | null
-  articles: NFTArticle[]
 }
-const _HomeHero = ({ randomGenerativeToken, articles }: HomeHeroProps) => {
+
+const _HomeHero = ({ randomGenerativeToken }: HomeHeroProps) => {
   const randomGenerativeTokenWithDups = useMemo(() => {
     // duplicate objkts when only two to have a pretty infinite loop
     if (randomGenerativeToken?.objkts.length !== 2) {
@@ -81,50 +58,6 @@ const _HomeHero = ({ randomGenerativeToken, articles }: HomeHeroProps) => {
                 onChangeCursor={setCursor}
               />
             )}
-          </div>
-        </div>
-      </div>
-      <div className={cs(style.articles_container, layout["padding-big"])}>
-        <div className={style.articles}>
-          <div className={style.docs}>
-            <h6>get started docs</h6>
-            <div>
-              {docs.map((doc) => (
-                <div className={style.doc} key={doc.title}>
-                  <Link href={doc.url}>
-                    <a>
-                      <span>{doc.title}</span>
-                    </a>
-                  </Link>
-                  <div className={style.subtitle}>{doc.subtitle}</div>
-                </div>
-              ))}
-            </div>
-          </div>
-          <div className={style.user_articles}>
-            <div>
-              <h6>community articles</h6>
-              <div>
-                {articles.map((article) => (
-                  <div className={style.user_article} key={article.id}>
-                    <Link href={`/article/${article.slug}`}>
-                      <a>
-                        <span className={style.title}>{article.title}</span>
-                      </a>
-                    </Link>
-                    <div className={style.subtitle}>
-                      <span className={style.written}>Written by</span>
-                      {article.author && (
-                        <UserBadge
-                          user={article.author}
-                          displayAvatar={false}
-                        />
-                      )}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
           </div>
         </div>
       </div>

--- a/src/containers/Homepage/HomeIncoming.tsx
+++ b/src/containers/Homepage/HomeIncoming.tsx
@@ -18,7 +18,7 @@ const _HomeIncoming = ({ generativeTokens }: HomeIncomingProps) => {
   return (
     <div className={cs(layout["padding-big"], style.container)}>
       <div className={style.container_title}>
-        <TitleHyphen>incoming</TitleHyphen>
+        <TitleHyphen>incoming projects</TitleHyphen>
         <Link href={"/explore/incoming"}>
           <a className={style.explore_more}>
             see all <i aria-hidden="true" className="fas fa-arrow-right" />

--- a/src/containers/Homepage/Homepage.tsx
+++ b/src/containers/Homepage/Homepage.tsx
@@ -9,6 +9,7 @@ import { NFTArticle } from "../../types/entities/Article"
 import { LiveMintingEvent } from "../../types/entities/LiveMinting"
 import { HomeEvents } from "./HomeEvents"
 import { HomeIncoming } from "./HomeIncoming"
+import { HomeDocs } from "./HomeDocs"
 
 interface HomepageProps {
   generativeTokens: GenerativeToken[]
@@ -27,15 +28,13 @@ const _Homepage = ({
 }: HomepageProps) => {
   return (
     <div className={style.container}>
-      <HomeHero
-        articles={articles}
-        randomGenerativeToken={randomGenerativeToken}
-      />
+      <HomeHero randomGenerativeToken={randomGenerativeToken} />
+      <HomeMarketplace />
       {events.length > 0 && <HomeEvents events={events} />}
+      <HomeDocs articles={articles} />
       {incomingTokens.length > 0 && (
         <HomeIncoming generativeTokens={incomingTokens} />
       )}
-      <HomeMarketplace />
       <HomeExplore generativeTokens={generativeTokens} />
       <HomeGetStarted />
     </div>

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -26,6 +26,7 @@ body {
   --color-error-20: rgba(255, 0, 0, 0.2);
   --color-warning: #ffc300;
   --color-warning-light: #ffc3003b;
+  --color-gray-vvvvlight: #f7f7f7;
   --color-gray-vvvlight: #f1f1f1;
   --color-gray-vvlight: #e7e7e7;
   --color-gray-vlight: #d3d3d3;


### PR DESCRIPTION
This PR implements the "event section redesign".
- Reorder sections on the homepage
- Redesign event cards

# UI/UX details

There are a few logical operations happening to display the information on the card:

#### Online vs. Offline Event Location

In the designs we see that an event can be online and somewhere located. 

<img width="567" alt="Screenshot 2023-07-06 at 15 04 53" src="https://github.com/fxhash/fxhash-website/assets/1128485/a0892715-6d0a-44eb-a02e-7674a7255b2c">

As of now we don't store "multiple locations" and/or offline vs. online event informations. Therefore we are either displaying the location of the event if it has one. If the event has no location specified it will automatically display as "online".

#### Event Time 

In the designs we are showing the different event dates in two ways. Either as a range from start to end OR the start date with the start time. 

<img width="946" alt="Screenshot 2023-07-06 at 15 07 27" src="https://github.com/fxhash/fxhash-website/assets/1128485/9b8631bf-42d8-43cd-800e-3698629582f0">

I implemented the following logic: 
- When event is ongoing we display the start date and end date
- When event is upcoming we display only the start date with the time it starts

Does that make sense?

# How to test
- Open the preview (see comment below from vercel bot)
- Navigate to the homepage
  - Confirm the order of all sections
- Checkout the Event section
  - Confirm new design
  - Confirm UI/UX details (see above)
  - Confirm layout on multiple breakpoints/screensizes/devices


# Implementation details

- I refactored the documentation section on the homepage into its own component for more flexibility in ordering the components
- Removed a lot of unused code from the old `CardEvent` component, because the new version is much more minimal