### PR TITLE
set allow-modals and * allow_list for allowed features

### DIFF
--- a/src/components/Artwork/PreviewIframe.tsx
+++ b/src/components/Artwork/PreviewIframe.tsx
@@ -87,14 +87,14 @@ export const ArtworkIframe = forwardRef<ArtworkIframeRef, Props>(
       <div className={cs(style["iframe-container"])}>
         <iframe
           ref={iframeRef}
-          sandbox="allow-scripts allow-same-origin"
+          sandbox="allow-scripts allow-same-origin allow-modals"
           className={cs(style.iframe)}
           onLoad={() => {
             onLoaded?.()
             setIframeLoaded()
           }}
           onError={() => setError(true)}
-          allow="accelerometer; camera; gyroscope; microphone; xr-spatial-tracking;"
+          allow="accelerometer *; camera *; gyroscope *; microphone *; xr-spatial-tracking *;"
         />
         {loading && hasLoading && !error && (
           <LoaderBlock height="100%" color="white" className={cs(style.loader)}>

--- a/src/components/Artwork/SandboxPreview.tsx
+++ b/src/components/Artwork/SandboxPreview.tsx
@@ -91,9 +91,10 @@ export const SandboxPreview = forwardRef<ArtworkIframeRef, Props>(
       <div className={cs(style["iframe-container"])}>
         <iframe
           ref={iframeRef}
-          sandbox="allow-scripts allow-same-origin"
+          sandbox="allow-scripts allow-same-origin allow-modals"
           className={cs(style.iframe)}
           onLoad={onLoaded}
+          allow="accelerometer *; camera *; gyroscope *; microphone *; xr-spatial-tracking *;"
         />
         {/* {loading &&(
         <LoaderBlock height="100%">{textWaiting}</LoaderBlock>

--- a/src/containers/MintGenerative/StepCheckFiles.tsx
+++ b/src/containers/MintGenerative/StepCheckFiles.tsx
@@ -18,6 +18,8 @@ import { MinterTest } from "components/Testing/MinterTest"
 import { useRuntimeController } from "hooks/useRuntimeController"
 import { IterationTest } from "components/Testing/IterationTest"
 import { ContextTest } from "components/Testing/ContextTest"
+import useIsMobile from "hooks/useIsMobile"
+import { breakpoints } from "hooks/useWindowsSize"
 
 export const StepCheckFiles: StepComponent = ({ onNext, state }) => {
   const [check1, setCheck1] = useState<boolean>(false)
@@ -71,6 +73,8 @@ export const StepCheckFiles: StepComponent = ({ onNext, state }) => {
     ),
     [details.activeUrl, runtime.state]
   )
+
+  const isMobile = useIsMobile(breakpoints.md)
   return (
     <>
       <p>
@@ -105,10 +109,12 @@ export const StepCheckFiles: StepComponent = ({ onNext, state }) => {
           </ul>
 
           <Spacing size="3x-large" sm="x-large" />
-          <div className={layout.show_sm}>
-            {artwork}
-            <Spacing size="3x-large" sm="x-large" />
-          </div>
+          {isMobile && (
+            <div>
+              {artwork}
+              <Spacing size="3x-large" sm="x-large" />
+            </div>
+          )}
 
           <HashTest
             autoGenerate={false}
@@ -158,9 +164,11 @@ export const StepCheckFiles: StepComponent = ({ onNext, state }) => {
             <RawFeatures rawFeatures={runtime.definition.features} />
           </div>
         </div>
-        <div className={layout.hide_sm}>
-          <div className={cs(style.artworkWrapper)}>{artwork}</div>
-        </div>
+        {!isMobile && (
+          <div>
+            <div className={cs(style.artworkWrapper)}>{artwork}</div>
+          </div>
+        )}
       </div>
 
       <Spacing size="6x-large" sm="x-large" />


### PR DESCRIPTION
It was reported that camera wasn't working. There were two issues:

- We need `allow-modals` so the iframe can actually trigger the modal to set permission for camera usage
- We also needed to set the allow_list for the features we allow for cross origin to allow in top-level browsing contexts and in nested contexts (iframes)

Reference: https://blog.addpipe.com/camera-and-microphone-access-in-cross-oirigin-iframes-with-feature-policy/

Aside from that we are now also always just rendering one iframe per breakpoint instead of hiding them via css