### PR TITLE
fallback to 3.2.0 snippetVersion on old projects

### DIFF
--- a/src/containers/MintWithTicket/MintWithTicketPage.tsx
+++ b/src/containers/MintWithTicket/MintWithTicketPage.tsx
@@ -94,7 +94,7 @@ export function MintWithTicketPageRoot({ token, ticketId, mode }: Props) {
       context: fxcontext,
       iteration: getRandomIteration(token.supply, token.balance),
       inputBytes,
-      snippetVersion: token.metadata.snippetVersion,
+      snippetVersion: token.metadata.snippetVersion || "3.2.0",
     },
     {
       autoRefresh: withAutoUpdate,


### PR DESCRIPTION
when a project doesn't have the snippetVersion in the metadata we have to explicitly fallback to 3.2.0 in order to use the old format of putting inputbytes in the query params

# How to test

- Click the params button below the artwork on dev it doesnt open with the input bytes already set but random: https://dev.fxhash-dev.xyz/gentk/FX1-1333
- Here the same link on this branch works: https://fxhash-git-fix-apply-default-snippet-version-when-99d0e5-fxhash.vercel.app/gentk/FX1-1333
