### PR TITLE
try to coerce zod options schema for `FxParamsOption` if numeric is string

### DIFF
--- a/src/components/FxParams/validation.ts
+++ b/src/components/FxParams/validation.ts
@@ -12,23 +12,23 @@ const ControllerTypeSchema = z.enum([
 ])
 
 const FxParamOptions_bigintSchema = z.object({
-  min: z.number().or(z.bigint()).optional(),
-  max: z.number().or(z.bigint()).optional(),
+  min: z.coerce.number().or(z.bigint()).optional(),
+  max: z.coerce.number().or(z.bigint()).optional(),
 })
 
 const FxParamOptions_numberSchema = z.object({
-  min: z.number().gte(Number.MIN_SAFE_INTEGER).optional(),
-  max: z.number().lte(Number.MAX_SAFE_INTEGER).optional(),
-  step: z.number().optional(),
+  min: z.coerce.number().gte(Number.MIN_SAFE_INTEGER).optional(),
+  max: z.coerce.number().lte(Number.MAX_SAFE_INTEGER).optional(),
+  step: z.coerce.number().optional(),
 })
 
 const FxParamOptions_stringSchema = z.object({
-  minLength: z.number().gte(0).optional(),
-  maxLength: z.number().optional(),
+  minLength: z.coerce.number().gte(0).optional(),
+  maxLength: z.coerce.number().optional(),
 })
 
 const FxParamOptions_bytesSchema = z.object({
-  length: z.number().gt(0),
+  length: z.coerce.number().gt(0),
 })
 
 const FxParamOptions_selectSchema = z.object({
@@ -60,7 +60,7 @@ const BytesControllerSchema = BaseControllerDefinitionSchema.extend({
 const NumberControllerSchema = BaseControllerDefinitionSchema.extend({
   type: z.literal(ControllerTypeSchema.enum.number),
   options: FxParamOptions_numberSchema.optional(),
-  default: z
+  default: z.coerce
     .number()
     .gte(Number.MIN_SAFE_INTEGER)
     .lte(Number.MAX_SAFE_INTEGER)


### PR DESCRIPTION
So my token was mintable at some point in the past without zod tossing an error up on the params abouot using a string'd numeric for this parameter... 

I want to make this free but also want to resolve the error as it is not a huge change to resolve, and as I mentioned, this was not throwing in the past.

This PR will coerce numeric values to a number if possible and be forgiving about passing strings as the options in `FxParamsOption` schemas.

![image](https://github.com/fxhash/fxhash-website/assets/1828125/560a3163-d54d-4f07-8ef0-a03fada29c3d)

https://www.fxhash.xyz/generative/slug/eye-pressure/explore-params
