### PR TITLE
Fixing Typos and Grammar in fxhash Documentation for Clarity

### DIFF
--- a/src/articles/changelog.md
+++ b/src/articles/changelog.md
@@ -36,7 +36,7 @@ description: 'The fxhash changelog'
 # 17/01/2021
 
 * cycles are now directly pulled from the contracts and UI reflects cycles in contracts
-* added supported for any number of cycles layered (off days are now displayed properly)
+* added support for any number of cycles layered (off days are now displayed properly)
 * added cycle IDs to the schedule (easier for communication)
 * improved the guides to collect, and to publish Generative Tokens
 * added guides to the header of the home page
@@ -87,7 +87,7 @@ description: 'The fxhash changelog'
 
 # 04/01/2022
 
-This update was introduced to prevent scammers from making profits using fxhash, and to secure collectors at the contract level. The Issuer contract was swapper for a new contract and all the data from the old one was transferred to provide the best experience for the community. Old tokens will benefit from the new feature `burn_supply`.
+This update was introduced to prevent scammers from making profits using fxhash, and to secure collectors at the contract level. The Issuer contract was swapped for a new contract and all the data from the old one was transferred to provide the best experience for the community. Old tokens will benefit from the new feature `burn_supply`.
 
 * update of the user moderation contract
   - on-chain views to give other contracts the ability to use the flags set by moderators
@@ -98,7 +98,7 @@ This update was introduced to prevent scammers from making profits using fxhash,
   - more modular architecture
   - the data of the old contract was transferred into the new one so that it does not impact users at all
   - added `burn_supply` endpoint for artists to burn remaining supply
-  - intoducing a 1 hour delay for the publication of Generative Tokens to prevent duplicates
+  - introducing a 1 hour delay for the publication of Generative Tokens to prevent duplicates
   - no more batch minting
   - 1-hour lock for new generative tokens only published by un-verified artists (to fight against scammers)
   - tokens moderated cannot be minted anymore

--- a/src/articles/collect-mint-tokens.md
+++ b/src/articles/collect-mint-tokens.md
@@ -46,7 +46,7 @@ We are currently experimenting with the opening schedule. Maybe it will stay, ma
 You can find the opening schedule under [/community/opening-schedule](/community/opening-schedule)
 
 
-# Temple with fxhash RPC (optionnal)
+# Temple with fxhash RPC (optional)
 
 *This is not required, but can help you send request with more success to the tezos blockchain*
 

--- a/src/articles/guide-mint-generative-token.md
+++ b/src/articles/guide-mint-generative-token.md
@@ -16,7 +16,7 @@ GT on fxhash can only be written in **html/css/javascript**. Ultimately, GT are 
 
 # General overview
 
-*This section will give you a rough overview of the Generative Tokens on fxhash. Don't worry if some informations are missing for you to properly understand the process, it will be covered later in this document.*
+*This section will give you a rough overview of the Generative Tokens on fxhash. Don't worry if some information are missing for you to properly understand the process, it will be covered later in this document.*
 
 ## 1. Upload and mint a GT
 
@@ -128,7 +128,7 @@ setTimeout(() => {
 }, 1000)
 ```
 
-Each propery of the `$fxhashFeatures` object will define one feature of the Tokens.
+Each property of the `$fxhashFeatures` object will define one feature of the Tokens.
 
 Features should also be derived from the `fxhash` string and from the `fxhash` string only. They should match the visual characteristics of the Token (ie reflect the settings behind the generative process of the token).
 
@@ -290,7 +290,7 @@ Testing often will also allow you to catch problems early that would become big 
 
 It is ideal if your token produces the same artwork at different sizes. Make sure to test your token often at different resolutions and DPRs. One of the most common pitfalls that artists fall into is not doing so and having their tokens look different at different sizes - as well as different to the preview - as a result.
 
-There are a number of different ways of getting your token to work in a resolution independent manor. Jump into the creator-support channel if you'd like to ask any questions.
+There are a number of different ways of getting your token to work in a resolution independent manner. Jump into the creator-support channel if you'd like to ask any questions.
 
 ## WebGL
 
@@ -310,7 +310,7 @@ One important thing to remember about WebGL is that you should be doing as mucho
 
 As of right now the preview system doesn't have a GPU. As such, rendering your scene falls to the CPU, which will render WebGL but at an extremely low framerate.
 
-If your token is WebGL then you want to make sure that you're rendering an accepable preview in the first couple of frames.
+If your token is WebGL then you want to make sure that you're rendering an acceptable preview in the first couple of frames.
 
 ## Computational complexity and previews
 


### PR DESCRIPTION
1. Fix: Incorrect word usage
File: changelog.md
Old: added supported for any number of cycles layered (off days are now displayed properly)
New: added support for any number of cycles layered (off days are now displayed properly)
Reason: supported (past tense verb) is incorrect in this context. The correct noun is support.
2. Fix: Incorrect past tense verb
File: changelog.md
Old: The Issuer contract was swapper for a new contract and all the data from the old one was transferred to provide the best experience for the community.
New: The Issuer contract was swapped for a new contract and all the data from the old one was transferred to provide the best experience for the community.
Reason: swapper is incorrect. The correct past tense verb is swapped.
3. Fix: Typographical error
File: changelog.md
Old: intoducing a 1 hour delay for the publication of Generative Tokens to prevent duplicates
New: introducing a 1 hour delay for the publication of Generative Tokens to prevent duplicates
Reason: Typo in intoducing → introducing.
4. Fix: Misspelled word ("optional")
File: guide-mint.md
Old: # Temple with fxhash RPC (optionnal)
New: # Temple with fxhash RPC (optional)
Reason: optionnal is a misspelling. The correct word is optional.
5. Fix: Incorrect pluralization ("information")
File: guide-mint.md
Old: Don't worry if some informations are missing for you to properly understand the process, it will be covered later in this document.
New: Don't worry if some information are missing for you to properly understand the process, it will be covered later in this document.
Reason: information is an uncountable noun in English and does not take an s.
6. Fix: Misspelled word ("property")
File: guide-mint.md
Old: Each propery of the $fxhashFeatures object will define one feature of the Tokens.
New: Each property of the $fxhashFeatures object will define one feature of the Tokens.
Reason: propery → property (typo).
7. Fix: Incorrect word usage ("manor" → "manner")
File: guide-mint.md
Old: There are a number of different ways of getting your token to work in a resolution independent manor.
New: There are a number of different ways of getting your token to work in a resolution independent manner.
Reason: manor refers to an estate or a large house. The correct word here is manner.
8. Fix: Misspelled word ("acceptable")
File: guide-mint.md
Old: If your token is WebGL then you want to make sure that you're rendering an accepable preview in the first couple of frames.
New: If your token is WebGL then you want to make sure that you're rendering an acceptable preview in the first couple of frames.
Reason: Typo in accepable → acceptable.